### PR TITLE
Fix/add support for bucket policy only

### DIFF
--- a/google/storage_bucket.go
+++ b/google/storage_bucket.go
@@ -53,6 +53,7 @@ func GetStorageBucketApiObject(d TerraformResourceData, config *Config) (map[str
 		Name:     bucket,
 		Labels:   expandLabels(d),
 		Location: location,
+		IamConfiguration: expandIamConfiguration(d),
 	}
 
 	if v, ok := d.GetOk("storage_class"); ok {
@@ -104,11 +105,6 @@ func GetStorageBucketApiObject(d TerraformResourceData, config *Config) (map[str
 			RequesterPays: v.(bool),
 		}
 	}
-
-	if v, ok := d.GetOk("bucket_policy_only"); ok {
-		sb.BucketPolicyOnly = v.(bool)
-	}
-
 
 	m, err := jsonMap(sb)
 	if err != nil {
@@ -265,3 +261,14 @@ func resourceGCSBucketLifecycleCreateOrUpdate(d TerraformResourceData, sb *stora
 
 	return nil
 }
+
+func expandIamConfiguration(d TerraformResourceData) *storage.BucketIamConfiguration {
+	return &storage.BucketIamConfiguration{
+		ForceSendFields: []string{"BucketPolicyOnly"},
+		BucketPolicyOnly: &storage.BucketIamConfigurationBucketPolicyOnly{
+			ForceSendFields: []string{"Enabled"},
+			Enabled:         d.Get("bucket_policy_only").(bool),
+		},
+	}
+}
+

--- a/google/storage_bucket.go
+++ b/google/storage_bucket.go
@@ -105,6 +105,11 @@ func GetStorageBucketApiObject(d TerraformResourceData, config *Config) (map[str
 		}
 	}
 
+	if v, ok := d.GetOk("bucket_policy_only"); ok {
+		sb.BucketPolicyOnly = v.(bool)
+	}
+
+
 	m, err := jsonMap(sb)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The magic-module source file [resource_storage_bucket.go](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/third_party/terraform/resources/resource_storage_bucket.go) has been updated to include support for **bucket_policy_only**. This file was modified to reflect such update