### PR TITLE
Bumped go version to 1.14

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,4 @@ require (
 	google.golang.org/api v0.35.0
 )
 
-go 1.13
+go 1.14


### PR DESCRIPTION
Related to https://github.com/GoogleCloudPlatform/terraform-validator/issues/158. I am still able to run `make test` successfully after this upgrade.