### PR TITLE
Update TFPlanToCAI function signature to follow the guideline at https://go.dev/blog/context-and-structs

### DIFF
--- a/conversion/tfplan_to_cai.go
+++ b/conversion/tfplan_to_cai.go
@@ -16,12 +16,11 @@ import (
 // Single struct for options so that adding new options does not require
 // updating function signatures all along the pipe
 type TFPlanToCAIOptions struct {
-	Context          *context.Context
 	ConvertUnchanged bool
 	ErrorLogger      *zap.Logger
 	Offline          bool
 	DefaultProject   string
-	// TODO: 
+	// TODO:
 	// DefaultRegion    string
 	// DefaultZone      string
 	// UserAgent for all requests (if online)
@@ -33,17 +32,11 @@ type TFPlanToCAIOptions struct {
 	AncestryCache map[string]string
 }
 
-type TFPlanToCAIFunc func(jsonPlan []byte, o *TFPlanToCAIOptions) ([]Asset, error)
+type TFPlanToCAIFunc func(ctx context.Context, jsonPlan []byte, o *TFPlanToCAIOptions) ([]Asset, error)
 
-func TFPlanToCAI(jsonPlan []byte, o *TFPlanToCAIOptions) ([]Asset, error) {
+func TFPlanToCAI(ctx context.Context, jsonPlan []byte, o *TFPlanToCAIOptions) ([]Asset, error) {
 	// Creates ancestry manager and converter internally; they are
 	// implementation details private to this package.
-	var ctx context.Context
-	if o.Context == nil {
-		ctx = context.Background()
-	} else {
-		ctx = *o.Context
-	}
 
 	errorLogger := o.ErrorLogger
 	if errorLogger == nil {

--- a/conversion/tfplan_to_cai_test.go
+++ b/conversion/tfplan_to_cai_test.go
@@ -1,6 +1,7 @@
 package conversion
 
 import (
+	"context"
 	"io/ioutil"
 	"testing"
 
@@ -8,21 +9,23 @@ import (
 )
 
 func TestTFPlanToCAI_noPlanJSON(t *testing.T) {
+	ctx := context.Background()
 	jsonPlan := []byte{}
 	options := &TFPlanToCAIOptions{}
-	assets, err := TFPlanToCAI(jsonPlan, options)
+	assets, err := TFPlanToCAI(ctx, jsonPlan, options)
 	assert.Empty(t, assets)
 	assert.Error(t, err)
 }
 
 func TestTFPlanToCAI_noResourceChanges(t *testing.T) {
+	ctx := context.Background()
 	f := "../testdata/empty-0.13.7.tfplan.json"
 	jsonPlan, err := ioutil.ReadFile(f)
 	if err != nil {
 		t.Fatalf("Error parsing %s: %s", f, err)
 	}
 	options := &TFPlanToCAIOptions{}
-	assets, err := TFPlanToCAI(jsonPlan, options)
+	assets, err := TFPlanToCAI(ctx, jsonPlan, options)
 	assert.Empty(t, assets)
 	assert.Empty(t, err)
 }


### PR DESCRIPTION
A context.Context object should not be stored inside a struct unless needed for backward compatibility and instead is to be explicitly passed as the first argument all along the function call chains.