### PR TITLE
Correct instance zone

### DIFF
--- a/cai2hcl/compute_instance.go
+++ b/cai2hcl/compute_instance.go
@@ -116,9 +116,10 @@ func (c *ComputeInstanceConverter) convertResourceData(asset *caiasset.Asset) (*
 	hclData["metadata"] = convertMetadata(instance.Metadata)
 
 	if instance.Zone == "" {
-		instance.Zone = parseFieldValue(asset.Name, "zones")
+		hclData["zone"] = parseFieldValue(asset.Name, "zones")
+	} else {
+		hclData["zone"] = parseFieldValue(instance.Zone, "zones")
 	}
-	hclData["zone"] = instance.Zone
 
 	ctyVal, err := mapToCtyValWithSchema(hclData, c.schema)
 	if err != nil {

--- a/testdata/full_compute_instance.json
+++ b/testdata/full_compute_instance.json
@@ -135,7 +135,8 @@
             "bar",
             "foo"
           ]
-        }
+        },
+        "zone": "projects/test-project/zones/us-central1-a"
       }
     }
   },


### PR DESCRIPTION
The zone now is like "zone": "projects/project-name/zones/us-east1-b"

It should be like "zone": "us-east1-b" instead

b/273835909