### PR TITLE
Revert "Update go version to 1.19"

### DIFF
--- a/.ci/cloudbuild-tests-go-licenses.yaml
+++ b/.ci/cloudbuild-tests-go-licenses.yaml
@@ -17,7 +17,7 @@
 timeout: 1800s
 steps:
   - id: test-go-licenses
-    name: "gcr.io/cloud-builders/go:1.19"
+    name: "gcr.io/cloud-builders/go:1.18"
     entrypoint: /usr/bin/make
     args: ["test-go-licenses"]
 tags:

--- a/.ci/cloudbuild-tests-unit.yaml
+++ b/.ci/cloudbuild-tests-unit.yaml
@@ -17,7 +17,7 @@
 timeout: 1800s
 steps:
   - id: test
-    name: "gcr.io/cloud-builders/go:1.19"
+    name: "gcr.io/cloud-builders/go:1.18"
     entrypoint: /usr/bin/make
     args: ["test"]
 tags:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19
+FROM golang:1.18
 RUN apt-get update && apt-get -y install wget unzip
 
 ENV TERRAFORM_VERSION 0.12.31

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/terraform-google-conversion/v2
 
-go 1.19
+go 1.18
 
 require (
 	cloud.google.com/go/bigtable v1.17.0
@@ -14,7 +14,6 @@ require (
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hcl/v2 v2.14.1
 	github.com/hashicorp/terraform-json v0.14.0
-	github.com/hashicorp/terraform-plugin-framework v1.1.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.0
 	github.com/hashicorp/terraform-provider-google v1.20.1-0.20230329175350-aa44f0e5ddb1
 	github.com/mitchellh/go-homedir v1.1.0
@@ -67,6 +66,7 @@ require (
 	github.com/hashicorp/hc-install v0.4.0 // indirect
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.17.3 // indirect
+	github.com/hashicorp/terraform-plugin-framework v1.1.1 // indirect
 	github.com/hashicorp/terraform-plugin-framework-validators v0.9.0 // indirect
 	github.com/hashicorp/terraform-plugin-go v0.14.3 // indirect
 	github.com/hashicorp/terraform-plugin-log v0.7.0 // indirect


### PR DESCRIPTION
Reverts GoogleCloudPlatform/terraform-google-conversion#820.  It looks like the Magic Modules downstream build pipeline is not compatible with go 1.19 at the moment - see https://pantheon.corp.google.com/cloud-build/builds/caef7cf1-bdda-4079-9d28-5e9c6d1957fb;step=10?jsmode=O&mods=logs_tg_staging&project=graphite-docker-images