### PR TITLE
Add cai2hcl converter for ComputeForwardingRule creation

### DIFF
--- a/cai2hcl/common.go
+++ b/cai2hcl/common.go
@@ -20,15 +20,17 @@ type HCLResourceBlock struct {
 
 // converterNames map key is the CAI Asset type, value is the TF resource name.
 var converterNames = map[string]string{
-	ComputeInstanceAssetType: "google_compute_instance",
-	ProjectAssetType:         "google_project",
-	ProjectBillingAssetType:  "google_project",
+	ComputeInstanceAssetType:       "google_compute_instance",
+	ComputeForwardingRuleAssetType: "google_compute_forwarding_rule",
+	ProjectAssetType:               "google_project",
+	ProjectBillingAssetType:        "google_project",
 }
 
 // converterMap initializes converters by their TF resource name.
 var converterMap = map[string]Converter{
-	"google_compute_instance": NewComputeInstanceConverter(),
-	"google_project":          NewProjectConverter(),
+	"google_compute_instance":        NewComputeInstanceConverter(),
+	"google_compute_forwarding_rule": NewComputeForwardingRuleConverter(),
+	"google_project":                 NewProjectConverter(),
 }
 
 // schemaProvider has schemas for all resources.

--- a/cai2hcl/compute_forwarding_rule.go
+++ b/cai2hcl/compute_forwarding_rule.go
@@ -1,0 +1,92 @@
+package cai2hcl
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v2/caiasset"
+
+	tfschema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"google.golang.org/api/compute/v1"
+)
+
+// ComputeForwardingRuleAssetType is the CAI asset type name for compute instance.
+const ComputeForwardingRuleAssetType string = "compute.googleapis.com/ForwardingRule"
+
+// ComputeForwardingRuleConverter for regional forwarding rule.
+type ComputeForwardingRuleConverter struct {
+	name   string
+	schema map[string]*tfschema.Schema
+}
+
+// NewComputeForwardingRuleConverter returns an HCL converter for compute instance.
+func NewComputeForwardingRuleConverter() *ComputeForwardingRuleConverter {
+	return &ComputeForwardingRuleConverter{
+		name:   "google_compute_forwarding_rule",
+		schema: schemaProvider.ResourcesMap["google_compute_forwarding_rule"].Schema,
+	}
+}
+
+// Convert converts asset to HCL resource blocks.
+func (c *ComputeForwardingRuleConverter) Convert(assets []*caiasset.Asset) ([]*HCLResourceBlock, error) {
+	var blocks []*HCLResourceBlock
+	for _, asset := range assets {
+		if asset == nil {
+			continue
+		}
+		if asset.Resource != nil && asset.Resource.Data != nil {
+			block, err := c.convertResourceData(asset)
+			if err != nil {
+				return nil, err
+			}
+			blocks = append(blocks, block)
+		}
+	}
+	return blocks, nil
+}
+
+// Convert REST payload to JSON/
+// Ported from https://github.com/hashicorp/terraform-provider-google/blob/main/google/resource_compute_forwarding_rule.go#L351
+func (c *ComputeForwardingRuleConverter) convertResourceData(asset *caiasset.Asset) (*HCLResourceBlock, error) {
+	if asset == nil || asset.Resource == nil || asset.Resource.Data == nil {
+		return nil, fmt.Errorf("asset resource data is nil")
+	}
+
+	var resource *compute.ForwardingRule
+	if err := decodeJSON(asset.Resource.Data, &resource); err != nil {
+		return nil, err
+	}
+
+	hcl := map[string]interface{}{
+		"name":                            resource.Name,
+		"all_ports":                       resource.AllPorts,
+		"allow_global_access":             resource.AllowGlobalAccess,
+		"backend_service":                 resource.BackendService,
+		"description":                     resource.Description,
+		"ip_address":                      resource.IPAddress,
+		"ip_protocol":                     resource.IPProtocol,
+		"is_mirroring_collector":          resource.IsMirroringCollector,
+		"labels":                          resource.Labels,
+		"load_balancing_scheme":           resource.LoadBalancingScheme,
+		"network":                         resource.Network,
+		"network_tier":                    resource.NetworkTier,
+		"port_range":                      resource.PortRange,
+		"ports":                           resource.Ports,
+		"subnetwork":                      resource.Subnetwork,
+		"target":                          resource.Target,
+		"service_label":                   resource.ServiceLabel,
+		"service_directory_registrations": resource.ServiceDirectoryRegistrations,
+	}
+
+	if resource.Region != "" {
+		hcl["region"] = parseFieldValue(resource.Region, "regions")
+	}
+
+	ctyVal, err := mapToCtyValWithSchema(hcl, c.schema)
+	if err != nil {
+		return nil, err
+	}
+	return &HCLResourceBlock{
+		Labels: []string{c.name, resource.Name},
+		Value:  ctyVal,
+	}, nil
+}

--- a/cai2hcl/compute_forwarding_rule_test.go
+++ b/cai2hcl/compute_forwarding_rule_test.go
@@ -4,12 +4,11 @@ import (
 	"testing"
 )
 
-func TestConvertProject(t *testing.T) {
+func TestConvertComputeForwardingRule(t *testing.T) {
 	cases := []struct {
 		name string
 	}{
-		{name: "project_create"},
-		{name: "project_iam"},
+		{name: "full_compute_forwarding_rule"},
 	}
 	for i := range cases {
 		c := cases[i]

--- a/cai2hcl/compute_instance_test.go
+++ b/cai2hcl/compute_instance_test.go
@@ -1,15 +1,7 @@
 package cai2hcl
 
 import (
-	"encoding/json"
-	"fmt"
-	"io/ioutil"
 	"testing"
-
-	"github.com/GoogleCloudPlatform/terraform-google-conversion/v2/caiasset"
-
-	"github.com/google/go-cmp/cmp"
-	"go.uber.org/zap"
 )
 
 func TestConvertComputeInstance(t *testing.T) {
@@ -21,32 +13,13 @@ func TestConvertComputeInstance(t *testing.T) {
 	}
 	for i := range cases {
 		c := cases[i]
+
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
-			assetFilePath := fmt.Sprintf("../testdata/%s.json", c.name)
-			expectedTFFilePath := fmt.Sprintf("../testdata/%s.tf", c.name)
-			assetPayload, err := ioutil.ReadFile(assetFilePath)
-			if err != nil {
-				t.Fatalf("cannot open %s, got: %s", assetFilePath, err)
-			}
-			want, err := ioutil.ReadFile(expectedTFFilePath)
-			if err != nil {
-				t.Fatalf("cannot open %s, got: %s", expectedTFFilePath, err)
-			}
 
-			var assets []*caiasset.Asset
-			if err := json.Unmarshal(assetPayload, &assets); err != nil {
-				t.Fatalf("cannot unmarshal: %s", err)
-			}
-
-			got, err := Convert(assets, &Options{
-				ErrorLogger: zap.NewNop(),
-			})
+			err := assertTestData(c.name)
 			if err != nil {
 				t.Fatal(err)
-			}
-			if diff := cmp.Diff(string(want), string(got)); diff != "" {
-				t.Errorf("cmp.Diff() got diff (-want +got): %s", diff)
 			}
 		})
 	}

--- a/cai2hcl/test_helper.go
+++ b/cai2hcl/test_helper.go
@@ -1,0 +1,43 @@
+package cai2hcl
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v2/caiasset"
+	"github.com/google/go-cmp/cmp"
+	"go.uber.org/zap"
+)
+
+func assertTestData(fileName string) (err error) {
+	assetFilePath := fmt.Sprintf("../testdata/%s.json", fileName)
+	expectedTfFilePath := fmt.Sprintf("../testdata/%s.tf", fileName)
+	assetPayload, err := ioutil.ReadFile(assetFilePath)
+	if err != nil {
+		return fmt.Errorf("cannot open %s, got: %s", assetFilePath, err)
+	}
+	want, err := ioutil.ReadFile(expectedTfFilePath)
+	if err != nil {
+		return fmt.Errorf("cannot open %s, got: %s", expectedTfFilePath, err)
+	}
+
+	var assets []*caiasset.Asset
+	if err := json.Unmarshal(assetPayload, &assets); err != nil {
+		return fmt.Errorf("cannot unmarshal: %s", err)
+	}
+
+	logger, err := zap.NewDevelopment()
+
+	got, err := Convert(assets, &Options{
+		ErrorLogger: logger,
+	})
+	if err != nil {
+		return err
+	}
+	if diff := cmp.Diff(string(want), string(got)); diff != "" {
+		return fmt.Errorf("cmp.Diff() got diff (-want +got): %s", diff)
+	}
+
+	return nil
+}

--- a/testdata/full_compute_forwarding_rule.json
+++ b/testdata/full_compute_forwarding_rule.json
@@ -1,0 +1,52 @@
+[
+  {
+    "name": "//compute.googleapis.com/projects/myproj/regions/us-central1/forwardingRules/test-1",
+    "asset_type": "compute.googleapis.com/ForwardingRule",
+    "ancestry_path": "organizations/123/folders/456/project/myproj",
+    "resource": {
+      "version": "v1",
+      "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/compute/v1/rest",
+      "discovery_name": "ForwardingRule",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/myproj",
+      "data": {
+        "name": "test-1",
+        "IPAddress": "10.128.0.62",
+        "IPProtocol": "TCP",
+        "allowGlobalAccess": false,
+        "loadBalancingScheme": "INTERNAL_MANAGED",
+        "description": "test description",
+        "networkTier": "PREMIUM",
+        "portRange": "80-82",
+        "region": "projects/myproj/regions/us-central1",
+        "subnetwork": "projects/myproj/regions/us-central1/subnetworks/default",
+        "target": "projects/myproj/regions/us-central1/targetHttpProxies/test1-target-proxy",
+        "allPorts": true
+      }
+    }
+  },
+  {
+    "name": "//compute.googleapis.com/projects/myproj/regions/us-central1/instances/test-2",
+    "asset_type": "compute.googleapis.com/ForwardingRule",
+    "ancestry_path": "organizations/123/folders/456/project/myproj",
+    "resource": {
+      "version": "v1",
+      "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/compute/v1/rest",
+      "discovery_name": "ForwardingRule",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/myproj",
+      "data": {
+        "name": "test-2",
+        "IPAddress": "projects/myproj/regions/us-central1/addresses/test-ip-1",
+        "IPProtocol": "TCP",
+        "backendService": "projects/myproj/regions/us-central1/backendServices/test-bs-1",
+        "ipVersion": "IPV6",
+        "loadBalancingScheme": "EXTERNAL",
+        "ports": [
+          "80",
+          "81"
+        ],
+        "region": "projects/myproj/regions/us-central1",
+        "all_ports": false
+      }
+    }
+  }
+]

--- a/testdata/full_compute_forwarding_rule.tf
+++ b/testdata/full_compute_forwarding_rule.tf
@@ -1,0 +1,28 @@
+resource "google_compute_forwarding_rule" "test-1" {
+  all_ports              = true
+  allow_global_access    = false
+  description            = "test description"
+  ip_address             = "10.128.0.62"
+  ip_protocol            = "TCP"
+  is_mirroring_collector = false
+  load_balancing_scheme  = "INTERNAL_MANAGED"
+  name                   = "test-1"
+  network_tier           = "PREMIUM"
+  port_range             = "80-82"
+  region                 = "us-central1"
+  subnetwork             = "projects/myproj/regions/us-central1/subnetworks/default"
+  target                 = "projects/myproj/regions/us-central1/targetHttpProxies/test1-target-proxy"
+}
+
+resource "google_compute_forwarding_rule" "test-2" {
+  all_ports              = false
+  allow_global_access    = false
+  backend_service        = "projects/myproj/regions/us-central1/backendServices/test-bs-1"
+  ip_address             = "projects/myproj/regions/us-central1/addresses/test-ip-1"
+  ip_protocol            = "TCP"
+  is_mirroring_collector = false
+  load_balancing_scheme  = "EXTERNAL"
+  name                   = "test-2"
+  ports                  = ["80", "81"]
+  region                 = "us-central1"
+}


### PR DESCRIPTION
This is a first step to support conversion from CAI to HCL for GCP Compute Load Balancing resources.