### PR TITLE
Import provider package

### DIFF
--- a/cai2hcl/common.go
+++ b/cai2hcl/common.go
@@ -2,7 +2,7 @@ package cai2hcl
 
 import (
 	"github.com/GoogleCloudPlatform/terraform-google-conversion/v2/caiasset"
-	tpg "github.com/hashicorp/terraform-provider-google-beta/google-beta"
+	tpg "github.com/hashicorp/terraform-provider-google-beta/google-beta/provider"
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/tfplan2cai/tfdata/fake_resource_data_test.go
+++ b/tfplan2cai/tfdata/fake_resource_data_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,7 @@ package tfdata
 import (
 	"testing"
 
-	provider "github.com/hashicorp/terraform-provider-google-beta/google-beta"
+	provider "github.com/hashicorp/terraform-provider-google-beta/google-beta/provider"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
Import provider package from `github.com/hashicorp/terraform-provider-google-beta/google-beta/provider` instead of `github.com/hashicorp/terraform-provider-google-beta/google-beta`, as the latter one will be cleaned up.