### PR TITLE
Update to Go 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/terraform-google-conversion/v2
 
-go 1.18
+go 1.20
 
 require (
 	github.com/apparentlymart/go-cidr v1.1.0


### PR DESCRIPTION
This PR accompanies this PR (https://github.com/GoogleCloudPlatform/magic-modules/pull/9506) to update the google and google-beta providers to Go 1.20