### PR TITLE
reference GOPATH directly

### DIFF
--- a/config-tf-dev-override.sh
+++ b/config-tf-dev-override.sh
@@ -25,7 +25,7 @@ if ! [ -f $TF_CONFIG_FILE ];then
     # Developer overrides will stop Terraform from downloading the listed
     # providers their origin provider registries.
     dev_overrides {
-        "hashicorp/google-beta" = "$GOPATH/bin"
+        "hashicorp/google-beta" = "$(go env GOPATH)/bin"
     }
     # For all other providers, install them directly from their origin provider
     # registries as normal. If you omit this, Terraform will _only_ use


### PR DESCRIPTION
Failures appeared in our CI pipeline since the VM doesn't actually state a GOPATH location.

https://github.com/GoogleCloudPlatform/magic-modules/actions/runs/7403766487/job/20144262649

Instead of fixing this in all the consumers I'm just going to fix it here.