### PR TITLE
Switched from PWD env var to pwd command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,13 @@ test:
 	go version
 	terraform --version
 	./config-tf-dev-override.sh
-	TF_CLI_CONFIG_FILE="${PWD}/${TF_CONFIG_FILE}" GO111MODULE=on go test -short ./...
+	TF_CLI_CONFIG_FILE="$${PWD}/${TF_CONFIG_FILE}" GO111MODULE=on go test -short ./...
 
 test-integration:
 	go version
 	terraform --version
 	./config-tf-dev-override.sh
-	TF_CLI_CONFIG_FILE="${PWD}/${TF_CONFIG_FILE}" go test -run=CLI ./...
+	TF_CLI_CONFIG_FILE="$${PWD}/${TF_CONFIG_FILE}" go test -run=CLI ./...
 
 test-go-licenses:
 	cd .. && go version && go install github.com/google/go-licenses@latest


### PR DESCRIPTION
This should fix unit tests by making them not rely on the presence of that env var