### PR TITLE
ancestrymanager: Prefer to use the project number

### DIFF
--- a/tfplan2cai/ancestrymanager/ancestrymanager.go
+++ b/tfplan2cai/ancestrymanager/ancestrymanager.go
@@ -80,8 +80,11 @@ func (m *manager) initAncestryCache(entries map[string]string) error {
 			if err != nil {
 				return err
 			}
-			// ancestry path should include the item itself
-			if ancestors[0] != key {
+			// The ancestry path should include the item itself, unless both the key and ancestor
+			// have the projects/ prefix, indicating the key is a project ID and the ancestry is
+			// project number. CAI ancestors use the project number, so that is preferred if it
+			// is available.
+			if ancestors[0] != key && !(strings.HasPrefix(key, projectPrefix) && strings.HasPrefix(ancestors[0], projectPrefix)) {
 				ancestors = append([]string{key}, ancestors...)
 			}
 			m.store(key, ancestors)

--- a/tfplan2cai/ancestrymanager/ancestrymanager_test.go
+++ b/tfplan2cai/ancestrymanager/ancestrymanager_test.go
@@ -1032,6 +1032,8 @@ func TestParseAncestryPath_Fail(t *testing.T) {
 }
 
 func TestInitAncestryCache(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		entries map[string]string
@@ -1082,9 +1084,23 @@ func TestInitAncestryCache(t *testing.T) {
 				"organizations/123":  {"organizations/123"},
 			},
 		},
+		{
+			name: "project id key with project number ancestry",
+			entries: map[string]string{
+				"projects/test-proj": "organizations/456/projects/123",
+			},
+			want: map[string][]string{
+				"projects/test-proj": {"projects/123", "organizations/456"},
+				"projects/123":       {"projects/123", "organizations/456"},
+				"organizations/456":  {"organizations/456"},
+			},
+		},
 	}
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			m := &manager{
 				ancestorCache: make(map[string][]string),
 			}


### PR DESCRIPTION
In CAI exports, the ancestors list always uses the project number and never the project ID. The converter uses the project ID for the lookup as many Terraform resources accept the project ID rather than the number. 

To work around this, users of the library may supply ancestry cache that is keyed on the project ID, but uses the project number in the ancestor list. Previously, the library would insert the project ID into the ancestors list which is incorrect behavior when the ancestors list already contains the project number.