### PR TITLE
fix: fix test-go-licenses command

### DIFF
--- a/.ci/cloudbuild-tests-go-licenses.yaml
+++ b/.ci/cloudbuild-tests-go-licenses.yaml
@@ -17,7 +17,7 @@
 timeout: 1800s
 steps:
   - id: test-go-licenses
-    name: "gcr.io/cloud-builders/go:1.18"
+    name: "gcr.io/graphite-docker-images/go-plus"
     entrypoint: /usr/bin/make
     args: ["test-go-licenses"]
 tags:


### PR DESCRIPTION
The reason for `test-go-licenses` failing before is that it uses go:1.18, which doesn't match with the current go version 1.23 of TGC.