### PR TITLE
feat: add V6 tfplan2cai cmd

### DIFF
--- a/v6/cmd/root.go
+++ b/v6/cmd/root.go
@@ -24,6 +24,7 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/cmd/common"
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/cmd/tfplan2cai"
 )
 
 const rootCmdDesc = `
@@ -73,6 +74,8 @@ func newRootCmd() (*cobra.Command, *common.RootOptions, error) {
 	}
 
 	cmd.PersistentFlags().StringVar(&o.Verbosity, "verbosity", "info", "Set verbosity level. One of: debug, info, warning, error, critical, none.")
+
+	cmd.AddCommand(tfplan2cai.NewCmd(o))
 
 	return cmd, o, nil
 }

--- a/v6/cmd/tfplan2cai/convert.go
+++ b/v6/cmd/tfplan2cai/convert.go
@@ -1,0 +1,160 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfplan2cai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/cmd/common"
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/caiasset"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+const convertDesc = `
+This command will convert a Terraform plan json file into Cloud Asset Inventory(CAI) assets
+and output them as a JSON array.
+
+Note:
+  Only supported resources will be converted. Non supported resources are
+  omitted from results.
+  Run "tgc tfplan2cai list-supported-resources" to see all supported
+  resources.
+
+Example:
+tgc tfplan2cai convert ./example/terraform.tfplan --project my-project \
+    --ancestry organization/my-org/folder/my-folder
+`
+
+func multiEnvSearch(ks []string) string {
+	for _, k := range ks {
+		if v := os.Getenv(k); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+type convertOptions struct {
+	project     string
+	ancestry    string
+	offline     bool
+	rootOptions *common.RootOptions
+	outputPath  string
+	dryRun      bool
+}
+
+var origConvertFunc = func(ctx context.Context, path, project, zone, region string, ancestry map[string]string, offline bool, errorLogger *zap.Logger, userAgent string) ([]caiasset.Asset, error) {
+	// TODO: add implementation
+	return nil, nil
+}
+
+var convertFunc = origConvertFunc
+
+func newConvertCmd(rootOptions *common.RootOptions) *cobra.Command {
+	o := &convertOptions{
+		rootOptions: rootOptions,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "convert TFPLAN_JSON",
+		Short: "convert a Terraform plan to Google CAI assets",
+		Long:  convertDesc,
+		PreRunE: func(c *cobra.Command, args []string) error {
+			return o.validateArgs(args)
+		},
+		RunE: func(c *cobra.Command, args []string) error {
+			if o.dryRun {
+				return nil
+			}
+			return o.run(args[0])
+		},
+	}
+
+	cmd.Flags().StringVar(&o.project, "project", "", "Provider project override (override the default project configuration assigned to the google terraform provider when converting resources)")
+	cmd.Flags().StringVar(&o.ancestry, "ancestry", "", "Override the ancestry location of the project when validating resources")
+	cmd.Flags().BoolVar(&o.offline, "offline", false, "Do not make network requests")
+	cmd.Flags().StringVar(&o.outputPath, "output-path", "", "If specified, write the convert result into the specified output file")
+	cmd.Flags().BoolVar(&o.dryRun, "dry-run", false, "Only parse & validate args")
+	cmd.Flags().MarkHidden("dry-run")
+
+	return cmd
+}
+
+func (o *convertOptions) validateArgs(args []string) error {
+	if len(args) != 1 {
+		return errors.New("missing required argument TFPLAN_JSON")
+	}
+	if o.offline && o.ancestry == "" {
+		return errors.New("please set ancestry via --ancestry in offline mode")
+	}
+	return nil
+}
+
+func (o *convertOptions) run(plan string) error {
+	ctx := context.Background()
+	ancestryCache := map[string]string{}
+	if o.project != "" {
+		ancestryCache[o.project] = o.ancestry
+	}
+	zone := multiEnvSearch([]string{
+		"GOOGLE_ZONE",
+		"GCLOUD_ZONE",
+		"CLOUDSDK_COMPUTE_ZONE",
+	})
+
+	region := multiEnvSearch([]string{
+		"GOOGLE_REGION",
+		"GCLOUD_REGION",
+		"CLOUDSDK_COMPUTE_REGION",
+	})
+	userAgent := "tfplan2cai"
+	assets, err := convertFunc(ctx, plan, o.project, zone, region, ancestryCache, o.offline, o.rootOptions.ErrorLogger, userAgent)
+	if err != nil {
+		return err
+	}
+
+	if len(o.outputPath) > 0 {
+		f, err := os.OpenFile(o.outputPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0666)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		if err := json.NewEncoder(f).Encode(assets); err != nil {
+			return fmt.Errorf("encoding json: %w", err)
+		}
+		return nil
+	}
+
+	if o.rootOptions.UseStructuredLogging {
+		o.rootOptions.OutputLogger.Info(
+			"converted resources",
+			zap.Any("resource_body", assets),
+		)
+		return nil
+	}
+
+	// Legacy behavior
+	if err := json.NewEncoder(os.Stdout).Encode(assets); err != nil {
+		return fmt.Errorf("encoding json: %w", err)
+	}
+	return nil
+}

--- a/v6/cmd/tfplan2cai/convert_test.go
+++ b/v6/cmd/tfplan2cai/convert_test.go
@@ -1,0 +1,361 @@
+package tfplan2cai
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/cmd/common"
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/caiasset"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func resetEnvKeys() []string {
+	return []string{
+		"GOOGLE_ZONE",
+		"GCLOUD_ZONE",
+		"CLOUDSDK_COMPUTE_ZONE",
+		"GOOGLE_REGION",
+		"GCLOUD_REGION",
+		"CLOUDSDK_COMPUTE_REGION",
+	}
+}
+
+func testAssets(path, project, zone, region string, ancestry map[string]string, offline bool, errorLogger *zap.Logger, userAgent string) []caiasset.Asset {
+	return []caiasset.Asset{
+		{
+			Name: "//compute.googleapis.com/projects/my-project/zones/us-central1-a/disks/test-disk",
+			Type: "compute.googleapis.com/Disk",
+			Resource: &caiasset.AssetResource{
+				Version:              "v1",
+				DiscoveryDocumentURI: "https://www.googleapis.com/discovery/v1/apis/compute/v1/rest",
+				DiscoveryName:        "Disk",
+				Data: map[string]interface{}{
+					"labels": map[string]string{
+						"environment": "dev",
+					},
+					"name":                   "test-disk",
+					"physicalBlockSizeBytes": 4096,
+					"sourceImage":            "projects/debian-cloud/global/images/debian-8-jessie-v20170523",
+					"type":                   "projects/my-project/zones/us-central1-a/diskTypes/pd-ssd",
+					"zone":                   "projects/my-project/global/zones/us-central1-a",
+					"arguments": map[string]interface{}{
+						"path":        path,
+						"project":     project,
+						"zone":        zone,
+						"region":      region,
+						"ancestry":    ancestry,
+						"offline":     offline,
+						"errorLogger": errorLogger,
+						"userAgent":   userAgent,
+					},
+				},
+			},
+		},
+	}
+}
+
+func mockConvertAssets(ctx context.Context, path, project, zone, region string, ancestry map[string]string, offline bool, errorLogger *zap.Logger, userAgent string) ([]caiasset.Asset, error) {
+	return testAssets(path, project, zone, region, ancestry, offline, errorLogger, userAgent), nil
+}
+
+func TestConvertRun(t *testing.T) {
+	convertFunc = mockConvertAssets
+	defer func() {
+		convertFunc = origConvertFunc
+	}()
+	for _, k := range resetEnvKeys() {
+		k := k
+		originalValue, isSet := os.LookupEnv(k)
+		if isSet {
+			defer os.Setenv(k, originalValue)
+		} else {
+			defer os.Unsetenv(k)
+		}
+		err := os.Setenv(k, "")
+		if err != nil {
+			t.Fatalf("error clearing env var %s: %s", k, err)
+		}
+	}
+
+	a := assert.New(t)
+	verbosity := "debug"
+	useStructuredLogging := true
+	errorLogger, errorBuf := common.NewTestErrorLogger(verbosity, useStructuredLogging)
+	outputLogger, outputBuf := common.NewTestOutputLogger()
+	ro := &common.RootOptions{
+		Verbosity:            verbosity,
+		UseStructuredLogging: useStructuredLogging,
+		ErrorLogger:          errorLogger,
+		OutputLogger:         outputLogger,
+	}
+	o := convertOptions{
+		project:     "",
+		ancestry:    "",
+		offline:     false,
+		rootOptions: ro,
+	}
+
+	path := "/path/to/plan"
+	err := o.run(path)
+	a.Nil(err)
+
+	errorJSON := errorBuf.String()
+	outputJSON := outputBuf.Bytes()
+
+	a.Equal(errorJSON, "")
+
+	var output map[string]interface{}
+	json.Unmarshal(outputJSON, &output)
+
+	// On a successful run, we should see a list of google assets in the resource_body field
+	a.Contains(output, "resource_body")
+	a.Len(output["resource_body"], 1)
+
+	var expectedAssets []interface{}
+	expectedAssetJSON, _ := json.Marshal(testAssets(path, "", "", "", map[string]string{}, false, errorLogger, "tfplan2cai"))
+	json.Unmarshal(expectedAssetJSON, &expectedAssets)
+	a.Equal(expectedAssets, output["resource_body"])
+}
+
+func TestConvertRunLegacy(t *testing.T) {
+	convertFunc = mockConvertAssets
+	defer func() {
+		convertFunc = origConvertFunc
+	}()
+	a := assert.New(t)
+	verbosity := "debug"
+	useStructuredLogging := false
+	errorLogger, errorBuf := common.NewTestErrorLogger(verbosity, useStructuredLogging)
+	outputLogger, outputBuf := common.NewTestOutputLogger()
+	ro := &common.RootOptions{
+		Verbosity:            verbosity,
+		UseStructuredLogging: useStructuredLogging,
+		ErrorLogger:          errorLogger,
+		OutputLogger:         outputLogger,
+	}
+	o := convertOptions{
+		project:     "",
+		ancestry:    "",
+		offline:     false,
+		rootOptions: ro,
+	}
+
+	err := o.run("/path/to/plan")
+	a.Nil(err)
+
+	errorJSON := errorBuf.String()
+	outputJSON := outputBuf.String()
+
+	// On a successful legacy run, we don't output anything via loggers.
+	a.Equal(errorJSON, "")
+	a.Equal(outputJSON, "")
+}
+
+func TestConvertRunOutputFile(t *testing.T) {
+	convertFunc = mockConvertAssets
+	defer func() {
+		convertFunc = origConvertFunc
+	}()
+	for _, k := range resetEnvKeys() {
+		k := k
+		originalValue, isSet := os.LookupEnv(k)
+		if isSet {
+			defer os.Setenv(k, originalValue)
+		} else {
+			defer os.Unsetenv(k)
+		}
+		err := os.Setenv(k, "")
+		if err != nil {
+			t.Fatalf("error clearing env var %s: %s", k, err)
+		}
+	}
+
+	a := assert.New(t)
+	verbosity := "debug"
+	useStructuredLogging := false
+	errorLogger, errorBuf := common.NewTestErrorLogger(verbosity, useStructuredLogging)
+	outputLogger, outputBuf := common.NewTestOutputLogger()
+	ro := &common.RootOptions{
+		Verbosity:            verbosity,
+		UseStructuredLogging: useStructuredLogging,
+		ErrorLogger:          errorLogger,
+		OutputLogger:         outputLogger,
+	}
+	outputPath := path.Join(t.TempDir(), "converted.json")
+	o := convertOptions{
+		project:     "",
+		ancestry:    "",
+		offline:     false,
+		rootOptions: ro,
+		outputPath:  outputPath,
+	}
+
+	path := "/path/to/plan"
+	err := o.run(path)
+	a.Nil(err)
+
+	errorJSON := errorBuf.String()
+	outputJSON := outputBuf.String()
+
+	a.Equal(errorJSON, "")
+	a.Equal(outputJSON, "")
+
+	b, err := os.ReadFile(outputPath)
+	if err != nil {
+		a.Failf("Unable to read file %s: %s", outputPath, err)
+	}
+	var gotAssets []interface{}
+	err = json.Unmarshal(b, &gotAssets)
+	if err != nil {
+		a.Failf("Failed to unmarshal file %s: %s", outputPath, err)
+	}
+
+	var expectedAssets []interface{}
+	expectedAssetJSON, _ := json.Marshal(testAssets(path, "", "", "", map[string]string{}, false, errorLogger, "tfplan2cai"))
+	json.Unmarshal(expectedAssetJSON, &expectedAssets)
+	a.Equal(expectedAssets, gotAssets)
+}
+
+func TestConvertRun_passesCorrectArguments(t *testing.T) {
+	convertFunc = mockConvertAssets
+	defer func() {
+		convertFunc = origConvertFunc
+	}()
+	cases := []struct {
+		name         string
+		project      string
+		ancestry     string
+		envKey       string
+		envValue     string
+		wantAncestry string
+		wantProject  string
+		wantZone     string
+		wantRegion   string
+	}{
+		{
+			name:        "project",
+			project:     "my-project",
+			wantProject: "my-project",
+		},
+		{
+			name:         "project with ancestry",
+			project:      "my-project",
+			ancestry:     "organizations/1234/folders/5678",
+			wantProject:  "my-project",
+			wantAncestry: "organizations/1234/folders/5678",
+		},
+		{
+			name:     "GOOGLE_ZONE",
+			envKey:   "GOOGLE_ZONE",
+			envValue: "whatever",
+			wantZone: "whatever",
+		},
+		{
+			name:     "GCLOUD_ZONE",
+			envKey:   "GCLOUD_ZONE",
+			envValue: "whatever",
+			wantZone: "whatever",
+		},
+		{
+			name:     "CLOUDSDK_COMPUTE_ZONE",
+			envKey:   "CLOUDSDK_COMPUTE_ZONE",
+			envValue: "whatever",
+			wantZone: "whatever",
+		},
+		{
+			name:       "GOOGLE_REGION",
+			envKey:     "GOOGLE_REGION",
+			envValue:   "whatever",
+			wantRegion: "whatever",
+		},
+		{
+			name:       "GCLOUD_REGION",
+			envKey:     "GCLOUD_REGION",
+			envValue:   "whatever",
+			wantRegion: "whatever",
+		},
+		{
+			name:       "CLOUDSDK_COMPUTE_REGION",
+			envKey:     "CLOUDSDK_COMPUTE_REGION",
+			envValue:   "whatever",
+			wantRegion: "whatever",
+		},
+	}
+
+	for _, k := range resetEnvKeys() {
+		k := k
+		originalValue, isSet := os.LookupEnv(k)
+		if isSet {
+			defer os.Setenv(k, originalValue)
+		} else {
+			defer os.Unsetenv(k)
+		}
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// clear env vars before each test
+			for _, k := range resetEnvKeys() {
+				err := os.Setenv(k, "")
+				if err != nil {
+					t.Fatalf("error clearing env var %s: %s", k, err)
+				}
+			}
+			if c.envKey != "" {
+				err := os.Setenv(c.envKey, c.envValue)
+				if err != nil {
+					t.Fatalf("error setting env var %s=%s: %s", c.envKey, c.envValue, err)
+				}
+
+			}
+
+			a := assert.New(t)
+			verbosity := "debug"
+			useStructuredLogging := true
+			errorLogger, errorBuf := common.NewTestErrorLogger(verbosity, useStructuredLogging)
+			outputLogger, outputBuf := common.NewTestOutputLogger()
+			ro := &common.RootOptions{
+				Verbosity:            verbosity,
+				UseStructuredLogging: useStructuredLogging,
+				ErrorLogger:          errorLogger,
+				OutputLogger:         outputLogger,
+			}
+			o := convertOptions{
+				project:     c.project,
+				ancestry:    c.ancestry,
+				offline:     false,
+				rootOptions: ro,
+			}
+
+			path := "/path/to/plan"
+			err := o.run(path)
+			a.Nil(err)
+
+			errorJSON := errorBuf.String()
+			outputJSON := outputBuf.Bytes()
+
+			a.Equal(errorJSON, "")
+
+			var output map[string]interface{}
+			json.Unmarshal(outputJSON, &output)
+
+			// On a successful run, we should see a list of google assets in the resource_body field
+			a.Contains(output, "resource_body")
+			a.Len(output["resource_body"], 1)
+
+			wantAncestryCache := map[string]string{}
+			if c.wantProject != "" {
+				wantAncestryCache[c.wantProject] = c.wantAncestry
+			}
+			var expectedAssets []interface{}
+			expectedAssetJSON, _ := json.Marshal(testAssets(path, c.wantProject, c.wantZone, c.wantRegion, wantAncestryCache, false, errorLogger, "tfplan2cai"))
+			json.Unmarshal(expectedAssetJSON, &expectedAssets)
+			a.Equal(expectedAssets, output["resource_body"])
+		})
+	}
+}

--- a/v6/cmd/tfplan2cai/tfplan2cai.go
+++ b/v6/cmd/tfplan2cai/tfplan2cai.go
@@ -1,0 +1,39 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfplan2cai
+
+import (
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/cmd/common"
+	"github.com/spf13/cobra"
+)
+
+const cmdDesc = `
+Support the convertion from Terraform resources data into the Cloud Asset Inventory(CAI) assets.
+
+Supported Terraform versions = 0.12+`
+
+func NewCmd(rootOptions *common.RootOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "tfplan2cai",
+		Short:         "Convert a Terraform plan to CAI assets",
+		Long:          cmdDesc,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+
+	cmd.AddCommand(newConvertCmd(rootOptions))
+
+	return cmd
+}

--- a/v6/pkg/caiasset/asset.go
+++ b/v6/pkg/caiasset/asset.go
@@ -1,0 +1,131 @@
+package caiasset
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Asset is the CAI representation of a resource.
+type Asset struct {
+	// The name, in a peculiar format: `\\<api>.googleapis.com/<self_link>`
+	Name string `json:"name"`
+	// The type name in `google.<api>.<resourcename>` format.
+	Type          string           `json:"asset_type"`
+	Resource      *AssetResource   `json:"resource,omitempty"`
+	IAMPolicy     *IAMPolicy       `json:"iam_policy,omitempty"`
+	OrgPolicy     []*OrgPolicy     `json:"org_policy,omitempty"`
+	V2OrgPolicies []*V2OrgPolicies `json:"v2_org_policies,omitempty"`
+	Ancestors     []string         `json:"ancestors"`
+}
+
+// IAMPolicy is the representation of a Cloud IAM policy set on a cloud resource.
+type IAMPolicy struct {
+	Bindings []IAMBinding `json:"bindings"`
+}
+
+// IAMBinding binds a role to a set of members.
+type IAMBinding struct {
+	Role    string   `json:"role"`
+	Members []string `json:"members"`
+}
+
+// AssetResource is nested within the Asset type.
+type AssetResource struct {
+	Version              string                 `json:"version"`
+	DiscoveryDocumentURI string                 `json:"discovery_document_uri"`
+	DiscoveryName        string                 `json:"discovery_name"`
+	Parent               string                 `json:"parent"`
+	Data                 map[string]interface{} `json:"data"`
+}
+
+// OrgPolicy is for managing organization policies.
+type OrgPolicy struct {
+	Constraint     string          `json:"constraint,omitempty"`
+	ListPolicy     *ListPolicy     `json:"list_policy,omitempty"`
+	BooleanPolicy  *BooleanPolicy  `json:"boolean_policy,omitempty"`
+	RestoreDefault *RestoreDefault `json:"restore_default,omitempty"`
+	UpdateTime     *Timestamp      `json:"update_time,omitempty"`
+}
+
+// V2OrgPolicies is the represtation of V2OrgPolicies
+type V2OrgPolicies struct {
+	Name       string      `json:"name"`
+	PolicySpec *PolicySpec `json:"spec,omitempty"`
+}
+
+// Spec is the representation of Spec for Custom Org Policy
+type PolicySpec struct {
+	Etag              string        `json:"etag,omitempty"`
+	UpdateTime        *Timestamp    `json:"update_time,omitempty"`
+	PolicyRules       []*PolicyRule `json:"rules,omitempty"`
+	InheritFromParent bool          `json:"inherit_from_parent,omitempty"`
+	Reset             bool          `json:"reset,omitempty"`
+}
+
+type PolicyRule struct {
+	Values    *StringValues `json:"values,omitempty"`
+	AllowAll  bool          `json:"allow_all,omitempty"`
+	DenyAll   bool          `json:"deny_all,omitempty"`
+	Enforce   bool          `json:"enforce,omitempty"`
+	Condition *Expr         `json:"condition,omitempty"`
+}
+
+type StringValues struct {
+	AllowedValues []string `json:"allowed_values,omitempty"`
+	DeniedValues  []string `json:"denied_values,omitempty"`
+}
+
+type Expr struct {
+	Expression  string `json:"expression,omitempty"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+	Location    string `json:"location,omitempty"`
+}
+
+type Timestamp struct {
+	Seconds int64 `json:"seconds,omitempty"`
+	Nanos   int64 `json:"nanos,omitempty"`
+}
+
+func (t Timestamp) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + time.Unix(0, t.Nanos).UTC().Format(time.RFC3339Nano) + `"`), nil
+}
+
+func (t *Timestamp) UnmarshalJSON(b []byte) error {
+	p, err := time.Parse(time.RFC3339Nano, strings.Trim(string(b), `"`))
+	if err != nil {
+		return fmt.Errorf("bad Timestamp: %v", err)
+	}
+	t.Seconds = p.Unix()
+	t.Nanos = p.UnixNano()
+	return nil
+}
+
+// ListPolicyAllValues is used to set `Policies` that apply to all possible
+// configuration values rather than specific values in `allowed_values` or
+// `denied_values`.
+type ListPolicyAllValues int32
+
+// ListPolicy can define specific values and subtrees of Cloud Resource
+// Manager resource hierarchy (`Organizations`, `Folders`, `Projects`) that
+// are allowed or denied by setting the `allowed_values` and `denied_values`
+// fields.
+type ListPolicy struct {
+	AllowedValues     []string            `json:"allowed_values,omitempty"`
+	DeniedValues      []string            `json:"denied_values,omitempty"`
+	AllValues         ListPolicyAllValues `json:"all_values,omitempty"`
+	SuggestedValue    string              `json:"suggested_value,omitempty"`
+	InheritFromParent bool                `json:"inherit_from_parent,omitempty"`
+}
+
+// BooleanPolicy If `true`, then the `Policy` is enforced. If `false`,
+// then any configuration is acceptable.
+type BooleanPolicy struct {
+	Enforced bool `json:"enforced,omitempty"`
+}
+
+// RestoreDefault determines if the default values of the `Constraints` are active for the
+// resources.
+type RestoreDefault struct {
+}


### PR DESCRIPTION
Copy the tfplan2cai command from v5 to v6 and then reorganize the folder structure

The supported command
tgc tfplan2cai convert ./example/terraform.tfplan --project my-project --ancestry organization/my-org/folder/my-folder
  