### PR TITLE
feat: add cai2hcl command to v6

### DIFF
--- a/v6/cmd/cai2hcl/cai2hcl.go
+++ b/v6/cmd/cai2hcl/cai2hcl.go
@@ -1,0 +1,41 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cai2hcl
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/cmd/common"
+)
+
+const cmdDesc = `
+Support the convertion from Cloud Asset Inventory(CAI) assets
+into Terraform HCL (HashiCorp Configuration Language) native syntax.
+
+Supported Terraform versions = 0.12+`
+
+func NewCmd(rootOptions *common.RootOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "cai2hcl",
+		Short:         "Convert CAI asset objects to Terraform HCL",
+		Long:          cmdDesc,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+
+	cmd.AddCommand(newConvertCmd(rootOptions))
+
+	return cmd
+}

--- a/v6/cmd/cai2hcl/convert.go
+++ b/v6/cmd/cai2hcl/convert.go
@@ -1,0 +1,124 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cai2hcl
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/cmd/common"
+)
+
+const convertDesc = `
+This command will convert a JSON file of Cloud Asset Inventory(CAI) assets
+into Terraform HCL (HashiCorp Configuration Language) native syntax.
+
+Note:
+  Only supported resources will be converted. Non supported resources are
+  omitted from results.
+
+Example:
+tgc cai2hcl convert ./example/caiassets.json
+`
+
+type convertOptions struct {
+	rootOptions *common.RootOptions
+	outputPath  string
+	dryRun      bool
+}
+
+var origConvertFunc = func(ctx context.Context, path string, errorLogger *zap.Logger) ([]byte, error) {
+	// TODO: add implementation
+	return nil, nil
+}
+
+var convertFunc = origConvertFunc
+
+func newConvertCmd(rootOptions *common.RootOptions) *cobra.Command {
+	o := &convertOptions{
+		rootOptions: rootOptions,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "convert CAI_ASSETS_JSON",
+		Short: "convert Google CAI assets into Terraform HCL",
+		Long:  convertDesc,
+		PreRunE: func(c *cobra.Command, args []string) error {
+			return o.validateArgs(args)
+		},
+		RunE: func(c *cobra.Command, args []string) error {
+			if o.dryRun {
+				return nil
+			}
+
+			return o.run(args[0])
+		},
+	}
+
+	cmd.Flags().StringVar(&o.outputPath, "output-path", "", "If specified, write the convert result into the specified output file")
+	cmd.Flags().BoolVar(&o.dryRun, "dry-run", false, "Only parse & validate args")
+	cmd.Flags().MarkHidden("dry-run")
+
+	return cmd
+}
+
+func (o *convertOptions) validateArgs(args []string) error {
+	if len(args) != 1 {
+		return errors.New("missing required argument CAI_ASSETS_JSON")
+	}
+	return nil
+}
+
+func (o *convertOptions) run(assets string) error {
+	ctx := context.Background()
+
+	hclBlocks, err := convertFunc(ctx, assets, o.rootOptions.ErrorLogger)
+	if err != nil {
+		return err
+	}
+
+	if len(o.outputPath) > 0 {
+		f, err := os.OpenFile(o.outputPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0666)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		err = ioutil.WriteFile(o.outputPath, hclBlocks, 0644)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	if o.rootOptions.UseStructuredLogging {
+		o.rootOptions.OutputLogger.Info(
+			"converted resources",
+			zap.String("resource_body", string(hclBlocks)),
+		)
+		return nil
+	}
+
+	os.Stdout.Write(hclBlocks)
+	os.Stdout.Write([]byte("\n")) // Add a newline
+
+	return nil
+}

--- a/v6/cmd/cai2hcl/convert_test.go
+++ b/v6/cmd/cai2hcl/convert_test.go
@@ -1,0 +1,147 @@
+package cai2hcl
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/cmd/common"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func testHCLBlocks() []byte {
+	testBlock := `
+resource "google_compute_forwarding_rule" "test-2" {
+  backend_service       = "projects/myproj/regions/us-central1/backendServices/test-bs-1"
+  ip_address            = "projects/myproj/regions/us-central1/addresses/test-ip-1"
+  ip_protocol           = "TCP"
+  ip_version            = "IPV6"
+  load_balancing_scheme = "EXTERNAL"
+  name                  = "test-2"
+  ports                 = ["80", "81"]
+  region                = "us-central1"
+}
+	`
+	return []byte(testBlock)
+}
+
+func mockConvertHCL(ctx context.Context, path string, errorLogger *zap.Logger) ([]byte, error) {
+	return testHCLBlocks(), nil
+}
+
+func TestConvertRun(t *testing.T) {
+	convertFunc = mockConvertHCL
+	defer func() {
+		convertFunc = origConvertFunc
+	}()
+	a := assert.New(t)
+	verbosity := "debug"
+	useStructuredLogging := true
+	errorLogger, errorBuf := common.NewTestErrorLogger(verbosity, useStructuredLogging)
+	outputLogger, outputBuf := common.NewTestOutputLogger()
+	ro := &common.RootOptions{
+		Verbosity:            verbosity,
+		UseStructuredLogging: useStructuredLogging,
+		ErrorLogger:          errorLogger,
+		OutputLogger:         outputLogger,
+	}
+	o := convertOptions{
+		rootOptions: ro,
+	}
+
+	path := "/path/to/cai_assets"
+	err := o.run(path)
+	a.Nil(err)
+
+	errorJSON := errorBuf.String()
+	outputJSON := outputBuf.Bytes()
+
+	a.Equal(errorJSON, "")
+
+	var output map[string]interface{}
+	json.Unmarshal(outputJSON, &output)
+
+	// On a successful run, we should see a list of google assets in the resource_body field
+	a.Contains(output, "resource_body")
+
+	var expectedHCLBlocks string
+	expectedHCLJSON, _ := json.Marshal(string(testHCLBlocks()))
+	json.Unmarshal(expectedHCLJSON, &expectedHCLBlocks)
+	a.Equal(expectedHCLBlocks, output["resource_body"])
+}
+
+func TestConvertRunLegacy(t *testing.T) {
+	convertFunc = mockConvertHCL
+	defer func() {
+		convertFunc = origConvertFunc
+	}()
+	a := assert.New(t)
+	verbosity := "debug"
+	useStructuredLogging := false
+	errorLogger, errorBuf := common.NewTestErrorLogger(verbosity, useStructuredLogging)
+	outputLogger, outputBuf := common.NewTestOutputLogger()
+	ro := &common.RootOptions{
+		Verbosity:            verbosity,
+		UseStructuredLogging: useStructuredLogging,
+		ErrorLogger:          errorLogger,
+		OutputLogger:         outputLogger,
+	}
+	o := convertOptions{
+		rootOptions: ro,
+	}
+
+	err := o.run("/path/to/plan")
+	a.Nil(err)
+
+	errorJSON := errorBuf.String()
+	outputJSON := outputBuf.String()
+
+	// On a successful legacy run, we don't output anything via loggers.
+	a.Equal(errorJSON, "")
+	a.Equal(outputJSON, "")
+}
+
+func TestConvertRunOutputFile(t *testing.T) {
+	convertFunc = mockConvertHCL
+	defer func() {
+		convertFunc = origConvertFunc
+	}()
+	a := assert.New(t)
+	verbosity := "debug"
+	useStructuredLogging := false
+	errorLogger, errorBuf := common.NewTestErrorLogger(verbosity, useStructuredLogging)
+	outputLogger, outputBuf := common.NewTestOutputLogger()
+	ro := &common.RootOptions{
+		Verbosity:            verbosity,
+		UseStructuredLogging: useStructuredLogging,
+		ErrorLogger:          errorLogger,
+		OutputLogger:         outputLogger,
+	}
+	outputPath := path.Join(t.TempDir(), "converted.json")
+	o := convertOptions{
+		rootOptions: ro,
+		outputPath:  outputPath,
+	}
+
+	path := "/path/to/plan"
+	err := o.run(path)
+	a.Nil(err)
+
+	errorJSON := errorBuf.String()
+	outputJSON := outputBuf.String()
+
+	a.Equal(errorJSON, "")
+	a.Equal(outputJSON, "")
+
+	b, err := os.ReadFile(outputPath)
+	if err != nil {
+		a.Failf("Unable to read file %s: %s", outputPath, err)
+	}
+
+	expectedHCLBlocks := testHCLBlocks()
+	a.Equal(expectedHCLBlocks, b)
+}

--- a/v6/cmd/root.go
+++ b/v6/cmd/root.go
@@ -23,6 +23,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/cmd/cai2hcl"
 	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/cmd/common"
 	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/cmd/tfplan2cai"
 )
@@ -76,6 +77,7 @@ func newRootCmd() (*cobra.Command, *common.RootOptions, error) {
 	cmd.PersistentFlags().StringVar(&o.Verbosity, "verbosity", "info", "Set verbosity level. One of: debug, info, warning, error, critical, none.")
 
 	cmd.AddCommand(tfplan2cai.NewCmd(o))
+	cmd.AddCommand(cai2hcl.NewCmd(o))
 
 	return cmd, o, nil
 }


### PR DESCRIPTION
This PR adds cai2hcl command to v6.

The supported command:

tgc cai2hcl convert ./example/example.json 