### PR TITLE
test: fix TestFakeResourceData_getOkTypeObject

### DIFF
--- a/tfplan2cai/tfdata/fake_resource_data_test.go
+++ b/tfplan2cai/tfdata/fake_resource_data_test.go
@@ -240,12 +240,14 @@ func TestFakeResourceData_getOkTypeObject(t *testing.T) {
 	)
 	res, ok := d.GetOk("attached_disk.0")
 	assert.Equal(t, map[string]interface{}{
-		"device_name":                "test-device_name",
-		"disk_encryption_key_raw":    "",
-		"disk_encryption_key_sha256": "",
-		"kms_key_self_link":          "test-kms_key_self_link",
-		"mode":                       "READ_ONLY",
-		"source":                     "test-source",
+		"device_name":                     "test-device_name",
+		"disk_encryption_key_raw":         "",
+		"disk_encryption_key_rsa":         "",
+		"disk_encryption_key_sha256":      "",
+		"disk_encryption_service_account": "",
+		"kms_key_self_link":               "test-kms_key_self_link",
+		"mode":                            "READ_ONLY",
+		"source":                          "test-source",
 	}, res)
 	assert.True(t, ok)
 }
@@ -315,12 +317,14 @@ func TestFakeResourceData_getOknsetTypeObject(t *testing.T) {
 	)
 	res, ok := d.GetOk("attached_disk.0")
 	assert.Equal(t, map[string]interface{}{
-		"device_name":                "",
-		"disk_encryption_key_raw":    "",
-		"disk_encryption_key_sha256": "",
-		"kms_key_self_link":          "",
-		"mode":                       "",
-		"source":                     "",
+		"device_name":                     "",
+		"disk_encryption_key_raw":         "",
+		"disk_encryption_key_rsa":         "",
+		"disk_encryption_key_sha256":      "",
+		"disk_encryption_service_account": "",
+		"kms_key_self_link":               "",
+		"mode":                            "",
+		"source":                          "",
 	}, res)
 	assert.False(t, ok)
 }


### PR DESCRIPTION
The new fields added in https://github.com/GoogleCloudPlatform/magic-modules/pull/12672 caused the test TestFakeResourceData_getOkTypeObject fail. This PR is going to fix this test.