### PR TITLE
feat: (tgc-revial) modify parameter type for cai2hcl

### DIFF
--- a/cmd/tgc/cai2hcl/convert.go
+++ b/cmd/tgc/cai2hcl/convert.go
@@ -54,7 +54,7 @@ var origConvertFunc = func(ctx context.Context, path string, errorLogger *zap.Lo
 		return nil, fmt.Errorf("error reading file %s: %s", path, err)
 	}
 
-	var assets []*caiasset.Asset
+	var assets []caiasset.Asset
 	if err := json.Unmarshal(assetPayload, &assets); err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,11 @@ require (
 	google.golang.org/api v0.229.0
 )
 
-require github.com/spf13/cobra v1.8.1
+require (
+	cloud.google.com/go/storage v1.43.0
+	github.com/joselitofilho/hcl-parser-go v0.2.0
+	github.com/spf13/cobra v1.8.1
+)
 
 require (
 	bitbucket.org/creachadair/stringset v0.0.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ cloud.google.com/go/longrunning v0.6.2 h1:xjDfh1pQcWPEvnfjZmwjKQEcHnpz6lHjfy7Fo0
 cloud.google.com/go/longrunning v0.6.2/go.mod h1:k/vIs83RN4bE3YCswdXC5PFfWVILjm3hpEUlSko4PiI=
 cloud.google.com/go/monitoring v1.21.2 h1:FChwVtClH19E7pJ+e0xUhJPGksctZNVOk2UhMmblmdU=
 cloud.google.com/go/monitoring v1.21.2/go.mod h1:hS3pXvaG8KgWTSz+dAdyzPrGUYmi2Q+WFX8g2hqVEZU=
+cloud.google.com/go/storage v1.43.0 h1:CcxnSohZwizt4LCzQHWvBf1/kvtHUn7gk9QERXPyXFs=
+cloud.google.com/go/storage v1.43.0/go.mod h1:ajvxEa7WmZS1PxvKRq4bq0tFT3vMd502JwstCcYv0Q0=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.78.0 h1:Mg4zefS6cVY5JEqrsjaWAcS2uUkkB7ttr5zJ3wERUek=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.78.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
@@ -117,6 +119,8 @@ github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/go-cpy v0.0.0-20211218193943-a9c933c06932 h1:5/4TSDzpDnHQ8rKEEQBjRlYx77mHOvXu08oGchxej7o=
 github.com/google/go-cpy v0.0.0-20211218193943-a9c933c06932/go.mod h1:cC6EdPbj/17GFCPDK39NRarlMI+kt+O60S12cNB5J9Y=
+github.com/google/martian/v3 v3.3.3 h1:DIhPTQrbPkgs2yJYdXU/eNACCG5DVQjySNRNlflZ9Fc=
+github.com/google/martian/v3 v3.3.3/go.mod h1:iEPrYcgCF7jA9OtScMFQyAlZZ4YXTKEtJ1E6RWzmBA0=
 github.com/google/s2a-go v0.1.9 h1:LGD7gtMgezd8a/Xak7mEWL0PjoTQFvpRudN895yqKW0=
 github.com/google/s2a-go v0.1.9/go.mod h1:YA0Ei2ZQL3acow2O62kdp9UlnvMmU7kA6Eutn0dXayM=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -185,6 +189,8 @@ github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/joselitofilho/hcl-parser-go v0.2.0 h1:o6GqRRtVfspmkDep/LA7fXPDBT+9uCSFphj5Bo+OTDk=
+github.com/joselitofilho/hcl-parser-go v0.2.0/go.mod h1:Bo8du9GpU07HNXTwmkwoNqdpNx6BmFmKz/aR3GaoxUo=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=


### PR DESCRIPTION
In the roundtrip testing, cai2hcl -> tfplan2cai -> cai2hcl -> tfplan2cai, the output of tfplan2cai will be the input of cai2hcl.
Currently, tfplan2cai returns `[]caiasset.Asset`, but the input of cai2hcl is `[]*caiasset.Asset`. To make the roundtrip testing work smoothly, change the input of cai2hcl to `[]caiasset.Asset`.

This PR needs to be merged together with PR https://github.com/GoogleCloudPlatform/magic-modules/pull/13719 to make the tests pass.