### PR TITLE
chore: increase the test timeout to 30m

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test:
 	go version
 	terraform --version
 	./config-tf-dev-override.sh
-	TF_CLI_CONFIG_FILE="$${PWD}/${TF_CONFIG_FILE}" GO111MODULE=on go test -short ./...
+	TF_CLI_CONFIG_FILE="$${PWD}/${TF_CONFIG_FILE}" GO111MODULE=on go test -timeout 30m -short ./...
 
 test-integration:
 	go version


### PR DESCRIPTION
Increase the test timeout to 30m for now to run tests with the new testing framework