### PR TITLE
chore: allow to run tests for one service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test:
 	go version
 	terraform --version
 	./config-tf-dev-override.sh
-	TF_CLI_CONFIG_FILE="$${PWD}/${TF_CONFIG_FILE}" GO111MODULE=on go test -timeout 30m -short ./...
+	TF_CLI_CONFIG_FILE="$${PWD}/${TF_CONFIG_FILE}" GO111MODULE=on go test $(TEST) $(TESTARGS) -timeout 30m -short ./...
 
 test-integration:
 	go version


### PR DESCRIPTION
Run all tests
```
make test
```

Run all tests in one service folder
```
make test TEST=./test/services/compute 
```

Run one test in one service folder
```
make test TEST=./test/services/compute  TESTARGS='-run=TestAccComputeInstance_partnerMetadata'
```

