### PR TITLE
chore: modify the test-integration command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test-integration:
 	go version
 	terraform --version
 	./config-tf-dev-override.sh
-	TF_CLI_CONFIG_FILE="$${PWD}/${TF_CONFIG_FILE}" GO111MODULE=on go test -run=Acc $(TESTPATH) $(TESTARGS) -timeout 30m -short ./...
+	TF_CLI_CONFIG_FILE="$${PWD}/${TF_CONFIG_FILE}" GO111MODULE=on go test -run=TestAcc $(TESTPATH) $(TESTARGS) -timeout 30m -short ./...
 
 test-go-licenses:
 	cd .. && go version && go install github.com/google/go-licenses@latest


### PR DESCRIPTION
`make test` is to run the tests excluding `test` folder.

`make test-integration` is to run the tests with `Acc`, for example `TestAccProject_parentFolder`

