### PR TITLE
Add location field to CAI Asset Resource Type

### DIFF
--- a/caiasset/asset.go
+++ b/caiasset/asset.go
@@ -37,6 +37,7 @@ type AssetResource struct {
 	DiscoveryName        string                 `json:"discovery_name"`
 	Parent               string                 `json:"parent"`
 	Data                 map[string]interface{} `json:"data"`
+	Location             string                 `json:"location,omitempty"`
 }
 
 // OrgPolicy is for managing organization policies.


### PR DESCRIPTION
Certificatemanager resources require a location field for implementation of cai2hcl mapping. Discussed with @zli82016
