### PR TITLE
Backport `networksecurity.googleapis.com/ServerTlsPolicy` to v5

### DIFF
--- a/cai2hcl/convert_test.go
+++ b/cai2hcl/convert_test.go
@@ -23,3 +23,12 @@ func TestConvertResourcemanager(t *testing.T) {
 			"project_create",
 		})
 }
+
+func TestConvertNetworksecurity(t *testing.T) {
+	cai2hclTesting.AssertTestFiles(
+		t,
+		"./services/networksecurity/testdata",
+		[]string{
+			"server_tls_policy",
+		})
+}

--- a/cai2hcl/converter_map.go
+++ b/cai2hcl/converter_map.go
@@ -1,10 +1,10 @@
 package cai2hcl
 
 import (
-	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/cai2hcl/common"
-	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/cai2hcl/services/compute"
-	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/cai2hcl/services/networksecurity"
-	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/cai2hcl/services/resourcemanager"
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v5/cai2hcl/common"
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v5/cai2hcl/services/compute"
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v5/cai2hcl/services/networksecurity"
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v5/cai2hcl/services/resourcemanager"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	tpg_provider "github.com/hashicorp/terraform-provider-google-beta/google-beta/provider"
 )

--- a/cai2hcl/converter_map.go
+++ b/cai2hcl/converter_map.go
@@ -1,9 +1,10 @@
 package cai2hcl
 
 import (
-	"github.com/GoogleCloudPlatform/terraform-google-conversion/v5/cai2hcl/common"
-	"github.com/GoogleCloudPlatform/terraform-google-conversion/v5/cai2hcl/services/compute"
-	"github.com/GoogleCloudPlatform/terraform-google-conversion/v5/cai2hcl/services/resourcemanager"
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/cai2hcl/common"
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/cai2hcl/services/compute"
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/cai2hcl/services/networksecurity"
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/cai2hcl/services/resourcemanager"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	tpg_provider "github.com/hashicorp/terraform-provider-google-beta/google-beta/provider"
 )
@@ -22,6 +23,8 @@ var AssetTypeToConverter = map[string]string{
 
 	resourcemanager.ProjectAssetType:        "google_project",
 	resourcemanager.ProjectBillingAssetType: "google_project",
+
+	networksecurity.ServerTLSPolicyAssetType: "google_network_security_server_tls_policy",
 }
 
 // ConverterMap is a collection of converters instances, indexed by name.
@@ -35,4 +38,6 @@ var ConverterMap = map[string]common.Converter{
 	"google_compute_region_health_check": compute.NewComputeRegionHealthCheckConverter(provider),
 
 	"google_project": resourcemanager.NewProjectConverter(provider),
+
+	"google_network_security_server_tls_policy": networksecurity.NewServerTLSPolicyConverter(provider),
 }

--- a/cai2hcl/services/networksecurity/server_tls_policy.go
+++ b/cai2hcl/services/networksecurity/server_tls_policy.go
@@ -1,0 +1,173 @@
+package networksecurity
+
+import (
+	"errors"
+	"fmt"
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/cai2hcl/common"
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/caiasset"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	netsecapi "google.golang.org/api/networksecurity/v1"
+	"strings"
+)
+
+// ServerTLSPolicyAssetType is the CAI asset type name.
+const ServerTLSPolicyAssetType string = "networksecurity.googleapis.com/ServerTlsPolicy"
+
+// ServerTLSPolicySchemaName is the TF resource schema name.
+const ServerTLSPolicySchemaName string = "google_network_security_server_tls_policy"
+
+// ServerTLSPolicyConverter for networksecurity server tls policy resource.
+type ServerTLSPolicyConverter struct {
+	name   string
+	schema map[string]*schema.Schema
+}
+
+// NewServerTLSPolicyConverter returns an HCL converter.
+func NewServerTLSPolicyConverter(provider *schema.Provider) common.Converter {
+	schema := provider.ResourcesMap[ServerTLSPolicySchemaName].Schema
+
+	return &ServerTLSPolicyConverter{
+		name:   ServerTLSPolicySchemaName,
+		schema: schema,
+	}
+}
+
+// Convert converts CAI assets to HCL resource blocks (Provider version: 6.45.0)
+func (c *ServerTLSPolicyConverter) Convert(assets []*caiasset.Asset) ([]*common.HCLResourceBlock, error) {
+	var blocks []*common.HCLResourceBlock
+	var err error
+
+	for _, asset := range assets {
+		if asset == nil {
+			continue
+		} else if asset.Resource == nil || asset.Resource.Data == nil {
+			return nil, fmt.Errorf("INVALID_ARGUMENT: Asset resource data is nil")
+		} else if asset.Type != ServerTLSPolicyAssetType {
+			return nil, fmt.Errorf("INVALID_ARGUMENT: Expected asset of type %s, but received %s", ServerTLSPolicyAssetType, asset.Type)
+		}
+		block, errConvert := c.convertResourceData(asset)
+		blocks = append(blocks, block)
+		if errConvert != nil {
+			err = errors.Join(err, errConvert)
+		}
+	}
+	return blocks, err
+}
+
+func (c *ServerTLSPolicyConverter) convertResourceData(asset *caiasset.Asset) (*common.HCLResourceBlock, error) {
+	if asset == nil || asset.Resource == nil || asset.Resource.Data == nil {
+		return nil, fmt.Errorf("INVALID_ARGUMENT: Asset resource data is nil")
+	}
+
+	hcl, _ := flattenServerTLSPolicy(asset.Resource)
+
+	ctyVal, err := common.MapToCtyValWithSchema(hcl, c.schema)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceName := hcl["name"].(string)
+	return &common.HCLResourceBlock{
+		Labels: []string{c.name, resourceName},
+		Value:  ctyVal,
+	}, nil
+}
+
+func flattenServerTLSPolicy(resource *caiasset.AssetResource) (map[string]any, error) {
+	result := make(map[string]any)
+
+	var serverTLSPolicy *netsecapi.ServerTlsPolicy
+	if err := common.DecodeJSON(resource.Data, &serverTLSPolicy); err != nil {
+		return nil, err
+	}
+
+	result["name"] = flattenName(serverTLSPolicy.Name)
+	result["labels"] = serverTLSPolicy.Labels
+	result["description"] = serverTLSPolicy.Description
+	result["allow_open"] = serverTLSPolicy.AllowOpen
+	result["server_certificate"] = flattenServerCertificate(serverTLSPolicy.ServerCertificate)
+	result["mtls_policy"] = flattenMTLSPolicy(serverTLSPolicy.MtlsPolicy)
+	result["project"] = flattenProjectName(serverTLSPolicy.Name)
+
+	result["location"] = resource.Location
+
+	return result, nil
+}
+
+func flattenName(name string) string {
+	tokens := strings.Split(name, "/")
+	return tokens[len(tokens)-1]
+}
+
+func flattenServerCertificate(certificate *netsecapi.GoogleCloudNetworksecurityV1CertificateProvider) []map[string]any {
+	if certificate == nil {
+		return nil
+	}
+
+	result := make(map[string]any)
+	result["certificate_provider_instance"] = flattenCertificateProviderInstance(certificate.CertificateProviderInstance)
+	result["grpc_endpoint"] = flattenGrpcEndpoint(certificate.GrpcEndpoint)
+
+	return []map[string]any{result}
+}
+
+func flattenMTLSPolicy(policy *netsecapi.MTLSPolicy) []map[string]any {
+	if policy == nil {
+		return nil
+	}
+
+	result := make(map[string]any)
+	result["client_validation_mode"] = policy.ClientValidationMode
+	result["client_validation_trust_config"] = policy.ClientValidationTrustConfig
+	result["client_validation_ca"] = flattenClientValidationCA(policy.ClientValidationCa)
+
+	return []map[string]any{result}
+}
+
+func flattenCertificateProviderInstance(instance *netsecapi.CertificateProviderInstance) []map[string]any {
+	if instance == nil {
+		return nil
+	}
+
+	result := make(map[string]any)
+	result["plugin_instance"] = instance.PluginInstance
+
+	return []map[string]any{result}
+}
+
+func flattenGrpcEndpoint(endpoint *netsecapi.GoogleCloudNetworksecurityV1GrpcEndpoint) []map[string]any {
+	if endpoint == nil {
+		return nil
+	}
+
+	result := make(map[string]any)
+	result["target_uri"] = endpoint.TargetUri
+
+	return []map[string]any{result}
+}
+
+func flattenClientValidationCA(cas []*netsecapi.ValidationCA) []map[string]any {
+	if cas == nil {
+		return nil
+	}
+
+	result := make([]map[string]any, 0, len(cas))
+
+	for _, ca := range cas {
+		converted := map[string]any{
+			"certificate_provider_instance": flattenCertificateProviderInstance(ca.CertificateProviderInstance),
+			"grpc_endpoint":                 flattenGrpcEndpoint(ca.GrpcEndpoint),
+		}
+		result = append(result, converted)
+	}
+
+	return result
+}
+
+func flattenProjectName(name string) string {
+	tokens := strings.Split(name, "/")
+	if len(tokens) < 2 || tokens[0] != "projects" {
+		return ""
+	}
+	return tokens[1]
+}

--- a/cai2hcl/services/networksecurity/server_tls_policy.go
+++ b/cai2hcl/services/networksecurity/server_tls_policy.go
@@ -3,8 +3,8 @@ package networksecurity
 import (
 	"errors"
 	"fmt"
-	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/cai2hcl/common"
-	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/caiasset"
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v5/cai2hcl/common"
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v5/caiasset"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netsecapi "google.golang.org/api/networksecurity/v1"
 	"strings"
@@ -88,8 +88,7 @@ func flattenServerTLSPolicy(resource *caiasset.AssetResource) (map[string]any, e
 	result["server_certificate"] = flattenServerCertificate(serverTLSPolicy.ServerCertificate)
 	result["mtls_policy"] = flattenMTLSPolicy(serverTLSPolicy.MtlsPolicy)
 	result["project"] = flattenProjectName(serverTLSPolicy.Name)
-
-	result["location"] = resource.Location
+	result["location"] = flattenLocation(serverTLSPolicy.Name)
 
 	return result, nil
 }
@@ -170,4 +169,12 @@ func flattenProjectName(name string) string {
 		return ""
 	}
 	return tokens[1]
+}
+
+func flattenLocation(name string) string {
+	tokens := strings.Split(name, "/")
+	if len(tokens) < 6 || tokens[2] != "locations" {
+		return ""
+	}
+	return tokens[3]
 }

--- a/cai2hcl/services/networksecurity/server_tls_policy_test.go
+++ b/cai2hcl/services/networksecurity/server_tls_policy_test.go
@@ -1,0 +1,13 @@
+package networksecurity_test
+
+import (
+	cai2hcl_testing "github.com/GoogleCloudPlatform/terraform-google-conversion/v6/cai2hcl/testing"
+	"testing"
+)
+
+func TestServerTlsPolicy(t *testing.T) {
+	cai2hcl_testing.AssertTestFiles(
+		t,
+		"./testdata",
+		[]string{"server_tls_policy"})
+}

--- a/cai2hcl/services/networksecurity/server_tls_policy_test.go
+++ b/cai2hcl/services/networksecurity/server_tls_policy_test.go
@@ -1,7 +1,7 @@
 package networksecurity_test
 
 import (
-	cai2hcl_testing "github.com/GoogleCloudPlatform/terraform-google-conversion/v6/cai2hcl/testing"
+	cai2hcl_testing "github.com/GoogleCloudPlatform/terraform-google-conversion/v5/cai2hcl/testing"
 	"testing"
 )
 

--- a/cai2hcl/services/networksecurity/testdata/server_tls_policy.json
+++ b/cai2hcl/services/networksecurity/testdata/server_tls_policy.json
@@ -1,0 +1,361 @@
+[
+  {
+    "ancestors": [
+      "projects/307841421122",
+      "folders/1004165107538",
+      "folders/422052295010",
+      "folders/23774682723",
+      "folders/134336129404",
+      "folders/376645683816",
+      "organizations/433637338589"
+    ],
+    "asset_type": "networksecurity.googleapis.com/ServerTlsPolicy",
+    "name": "//networksecurity.googleapis.com/projects/ccm-breakit/locations/global/serverTlsPolicies/lb_mtls_policy",
+    "resource": {
+      "data": {
+        "createTime": "2025-07-29T16:00:11.184079186Z",
+        "description": "my description",
+        "labels": {
+          "foo": "bar"
+        },
+        "mtlsPolicy": {
+          "clientValidationMode": "REJECT_INVALID",
+          "clientValidationTrustConfig": "projects/307841421122/locations/global/trustConfigs/id-4adf7779-1e9f-4124-9438-652c80886074"
+        },
+        "name": "projects/ccm-breakit/locations/global/serverTlsPolicies/lb_mtls_policy",
+        "updateTime": "2025-07-29T16:00:15.415731403Z"
+      },
+      "discovery_document_uri": "https://networksecurity.googleapis.com/$discovery/rest",
+      "discovery_name": "ServerTlsPolicy",
+      "location": "global",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/307841421122",
+      "version": "v1"
+    },
+    "updateTime": "2025-07-29T18:00:00Z"
+  },
+  {
+    "ancestors": [
+      "projects/307841421122",
+      "folders/1004165107538",
+      "folders/422052295010",
+      "folders/23774682723",
+      "folders/134336129404",
+      "folders/376645683816",
+      "organizations/433637338589"
+    ],
+    "asset_type": "networksecurity.googleapis.com/ServerTlsPolicy",
+    "name": "//networksecurity.googleapis.com/projects/ccm-breakit/locations/global/serverTlsPolicies/td_mtls_policy",
+    "resource": {
+      "data": {
+        "createTime": "2025-07-29T16:00:12.082558809Z",
+        "description": "my description",
+        "labels": {
+          "foo": "bar"
+        },
+        "mtlsPolicy": {
+          "clientValidationCa": [
+            {
+              "certificateProviderInstance": {
+                "pluginInstance": "google_cloud_private_spiffe"
+              }
+            }
+          ]
+        },
+        "name": "projects/ccm-breakit/locations/global/serverTlsPolicies/td_mtls_policy",
+        "serverCertificate": {
+          "certificateProviderInstance": {
+            "pluginInstance": "google_cloud_private_spiffe"
+          }
+        },
+        "updateTime": "2025-07-29T16:00:15.692522561Z"
+      },
+      "discovery_document_uri": "https://networksecurity.googleapis.com/$discovery/rest",
+      "discovery_name": "ServerTlsPolicy",
+      "location": "global",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/307841421122",
+      "version": "v1"
+    },
+    "updateTime": "2025-07-29T18:00:00Z"
+  },
+  {
+    "ancestors": [
+      "projects/307841421122",
+      "folders/1004165107538",
+      "folders/422052295010",
+      "folders/23774682723",
+      "folders/134336129404",
+      "folders/376645683816",
+      "organizations/433637338589"
+    ],
+    "asset_type": "networksecurity.googleapis.com/ServerTlsPolicy",
+    "name": "//networksecurity.googleapis.com/projects/ccm-breakit/locations/global/serverTlsPolicies/td_with_server_cert_policy",
+    "resource": {
+      "data": {
+        "createTime": "2025-07-29T16:00:12.040588118Z",
+        "description": "my description",
+        "name": "projects/ccm-breakit/locations/global/serverTlsPolicies/td_with_server_cert_policy",
+        "serverCertificate": {
+          "grpcEndpoint": {
+            "targetUri": "unix:mypath"
+          }
+        },
+        "updateTime": "2025-07-29T16:00:15.680321984Z"
+      },
+      "discovery_document_uri": "https://networksecurity.googleapis.com/$discovery/rest",
+      "discovery_name": "ServerTlsPolicy",
+      "location": "global",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/307841421122",
+      "version": "v1"
+    },
+    "updateTime": "2025-07-29T18:00:00Z"
+  },
+  {
+    "ancestors": [
+      "projects/307841421122",
+      "folders/1004165107538",
+      "folders/422052295010",
+      "folders/23774682723",
+      "folders/134336129404",
+      "folders/376645683816",
+      "organizations/433637338589"
+    ],
+    "asset_type": "networksecurity.googleapis.com/ServerTlsPolicy",
+    "name": "//networksecurity.googleapis.com/projects/ccm-breakit/locations/global/serverTlsPolicies/empty_description_policy",
+    "resource": {
+      "data": {
+        "createTime": "2025-07-29T16:00:11.660089355Z",
+        "labels": {
+          "foo": "bar"
+        },
+        "mtlsPolicy": {
+          "clientValidationMode": "REJECT_INVALID",
+          "clientValidationTrustConfig": "projects/307841421122/locations/global/trustConfigs/id-4adf7779-1e9f-4124-9438-652c80886074"
+        },
+        "name": "projects/ccm-breakit/locations/global/serverTlsPolicies/empty_description_policy",
+        "updateTime": "2025-07-29T16:00:16.847799545Z"
+      },
+      "discovery_document_uri": "https://networksecurity.googleapis.com/$discovery/rest",
+      "discovery_name": "ServerTlsPolicy",
+      "location": "global",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/307841421122",
+      "version": "v1"
+    },
+    "updateTime": "2025-07-29T18:00:00Z"
+  },
+  {
+    "ancestors": [
+      "projects/307841421122",
+      "folders/1004165107538",
+      "folders/422052295010",
+      "folders/23774682723",
+      "folders/134336129404",
+      "folders/376645683816",
+      "organizations/433637338589"
+    ],
+    "asset_type": "networksecurity.googleapis.com/ServerTlsPolicy",
+    "name": "//networksecurity.googleapis.com/projects/ccm-breakit/locations/global/serverTlsPolicies/empty_labels_policy",
+    "resource": {
+      "data": {
+        "createTime": "2025-07-29T16:00:12.040240475Z",
+        "description": "my description",
+        "mtlsPolicy": {
+          "clientValidationMode": "REJECT_INVALID",
+          "clientValidationTrustConfig": "projects/307841421122/locations/global/trustConfigs/id-4adf7779-1e9f-4124-9438-652c80886074"
+        },
+        "name": "projects/ccm-breakit/locations/global/serverTlsPolicies/empty_labels_policy",
+        "updateTime": "2025-07-29T16:00:16.309813819Z"
+      },
+      "discovery_document_uri": "https://networksecurity.googleapis.com/$discovery/rest",
+      "discovery_name": "ServerTlsPolicy",
+      "location": "global",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/307841421122",
+      "version": "v1"
+    },
+    "updateTime": "2025-07-29T18:00:00Z"
+  },
+  {
+    "ancestors": [
+      "projects/307841421122",
+      "folders/1004165107538",
+      "folders/422052295010",
+      "folders/23774682723",
+      "folders/134336129404",
+      "folders/376645683816",
+      "organizations/433637338589"
+    ],
+    "asset_type": "networksecurity.googleapis.com/ServerTlsPolicy",
+    "name": "//networksecurity.googleapis.com/projects/ccm-breakit/locations/us-central1/serverTlsPolicies/regional_location_policy",
+    "resource": {
+      "data": {
+        "createTime": "2025-07-29T16:00:12.162242768Z",
+        "description": "my description",
+        "labels": {
+          "foo": "bar"
+        },
+        "mtlsPolicy": {
+          "clientValidationMode": "REJECT_INVALID",
+          "clientValidationTrustConfig": "projects/307841421122/locations/us-central1/trustConfigs/tsmx-20250609-tc1"
+        },
+        "name": "projects/ccm-breakit/locations/us-central1/serverTlsPolicies/regional_location_policy",
+        "updateTime": "2025-07-29T16:00:15.08724113Z"
+      },
+      "discovery_document_uri": "https://networksecurity.googleapis.com/$discovery/rest",
+      "discovery_name": "ServerTlsPolicy",
+      "location": "us-central1",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/307841421122",
+      "version": "v1"
+    },
+    "updateTime": "2025-07-29T18:00:00Z"
+  },
+  {
+    "ancestors": [
+      "projects/307841421122",
+      "folders/1004165107538",
+      "folders/422052295010",
+      "folders/23774682723",
+      "folders/134336129404",
+      "folders/376645683816",
+      "organizations/433637338589"
+    ],
+    "asset_type": "networksecurity.googleapis.com/ServerTlsPolicy",
+    "name": "//networksecurity.googleapis.com/projects/ccm-breakit/locations/global/serverTlsPolicies/lb_mtls_allow_invalid_cert_policy",
+    "resource": {
+      "data": {
+        "createTime": "2025-07-29T16:00:12.078450339Z",
+        "description": "my description",
+        "labels": {
+          "foo": "bar"
+        },
+        "mtlsPolicy": {
+          "clientValidationMode": "ALLOW_INVALID_OR_MISSING_CLIENT_CERT"
+        },
+        "name": "projects/ccm-breakit/locations/global/serverTlsPolicies/lb_mtls_allow_invalid_cert_policy",
+        "updateTime": "2025-07-29T16:00:16.300643457Z"
+      },
+      "discovery_document_uri": "https://networksecurity.googleapis.com/$discovery/rest",
+      "discovery_name": "ServerTlsPolicy",
+      "location": "global",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/307841421122",
+      "version": "v1"
+    },
+    "updateTime": "2025-07-29T18:00:00Z"
+  },
+  {
+    "ancestors": [
+      "projects/307841421122",
+      "folders/1004165107538",
+      "folders/422052295010",
+      "folders/23774682723",
+      "folders/134336129404",
+      "folders/376645683816",
+      "organizations/433637338589"
+    ],
+    "asset_type": "networksecurity.googleapis.com/ServerTlsPolicy",
+    "name": "//networksecurity.googleapis.com/projects/ccm-breakit/locations/global/serverTlsPolicies/td_allow_open_policy",
+    "resource": {
+      "data": {
+        "allowOpen": true,
+        "createTime": "2025-07-29T16:00:11.930403186Z",
+        "description": "my description",
+        "mtlsPolicy": {
+          "clientValidationCa": [
+            {
+              "certificateProviderInstance": {
+                "pluginInstance": "google_cloud_private_spiffe"
+              }
+            }
+          ]
+        },
+        "name": "projects/ccm-breakit/locations/global/serverTlsPolicies/td_allow_open_policy",
+        "serverCertificate": {
+          "grpcEndpoint": {
+            "targetUri": "unix:mypath"
+          }
+        },
+        "updateTime": "2025-07-29T16:00:15.644106332Z"
+      },
+      "discovery_document_uri": "https://networksecurity.googleapis.com/$discovery/rest",
+      "discovery_name": "ServerTlsPolicy",
+      "location": "global",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/307841421122",
+      "version": "v1"
+    },
+    "updateTime": "2025-07-29T18:00:00Z"
+  },
+  {
+    "ancestors": [
+      "projects/307841421122",
+      "folders/1004165107538",
+      "folders/422052295010",
+      "folders/23774682723",
+      "folders/134336129404",
+      "folders/376645683816",
+      "organizations/433637338589"
+    ],
+    "asset_type": "networksecurity.googleapis.com/ServerTlsPolicy",
+    "name": "//networksecurity.googleapis.com/projects/ccm-breakit/locations/global/serverTlsPolicies/td_with_cert_provider_policy",
+    "resource": {
+      "data": {
+        "createTime": "2025-07-29T16:00:12.122393281Z",
+        "description": "my description",
+        "name": "projects/ccm-breakit/locations/global/serverTlsPolicies/td_with_cert_provider_policy",
+        "serverCertificate": {
+          "certificateProviderInstance": {
+            "pluginInstance": "google_cloud_private_spiffe"
+          }
+        },
+        "updateTime": "2025-07-29T16:00:15.720820072Z"
+      },
+      "discovery_document_uri": "https://networksecurity.googleapis.com/$discovery/rest",
+      "discovery_name": "ServerTlsPolicy",
+      "location": "global",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/307841421122",
+      "version": "v1"
+    },
+    "updateTime": "2025-07-29T18:00:00Z"
+  },
+  {
+    "ancestors": [
+      "projects/307841421122",
+      "folders/1004165107538",
+      "folders/422052295010",
+      "folders/23774682723",
+      "folders/134336129404",
+      "folders/376645683816",
+      "organizations/433637338589"
+    ],
+    "asset_type": "networksecurity.googleapis.com/ServerTlsPolicy",
+    "name": "//networksecurity.googleapis.com/projects/ccm-breakit/locations/global/serverTlsPolicies/td_mtls_client_validation_grpc_policy",
+    "resource": {
+      "data": {
+        "createTime": "2025-07-29T16:00:12.000713965Z",
+        "description": "my description",
+        "labels": {
+          "foo": "bar"
+        },
+        "mtlsPolicy": {
+          "clientValidationCa": [
+            {
+              "grpcEndpoint": {
+                "targetUri": "unix:mypath"
+              }
+            }
+          ]
+        },
+        "name": "projects/ccm-breakit/locations/global/serverTlsPolicies/td_mtls_client_validation_grpc_policy",
+        "serverCertificate": {
+          "certificateProviderInstance": {
+            "pluginInstance": "google_cloud_private_spiffe"
+          }
+        },
+        "updateTime": "2025-07-29T16:00:15.701713898Z"
+      },
+      "discovery_document_uri": "https://networksecurity.googleapis.com/$discovery/rest",
+      "discovery_name": "ServerTlsPolicy",
+      "location": "global",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/307841421122",
+      "version": "v1"
+    },
+    "updateTime": "2025-07-29T18:00:00Z"
+  }
+]

--- a/cai2hcl/services/networksecurity/testdata/server_tls_policy.json
+++ b/cai2hcl/services/networksecurity/testdata/server_tls_policy.json
@@ -13,7 +13,7 @@
     "name": "//networksecurity.googleapis.com/projects/ccm-breakit/locations/global/serverTlsPolicies/lb_mtls_policy",
     "resource": {
       "data": {
-        "createTime": "2025-07-29T16:00:11.184079186Z",
+        "createTime": "2025-08-05T16:25:14.331266021Z",
         "description": "my description",
         "labels": {
           "foo": "bar"
@@ -23,7 +23,7 @@
           "clientValidationTrustConfig": "projects/307841421122/locations/global/trustConfigs/id-4adf7779-1e9f-4124-9438-652c80886074"
         },
         "name": "projects/ccm-breakit/locations/global/serverTlsPolicies/lb_mtls_policy",
-        "updateTime": "2025-07-29T16:00:15.415731403Z"
+        "updateTime": "2025-08-05T16:25:21.105490028Z"
       },
       "discovery_document_uri": "https://networksecurity.googleapis.com/$discovery/rest",
       "discovery_name": "ServerTlsPolicy",
@@ -31,7 +31,7 @@
       "parent": "//cloudresourcemanager.googleapis.com/projects/307841421122",
       "version": "v1"
     },
-    "updateTime": "2025-07-29T18:00:00Z"
+    "updateTime": "2025-08-05T18:00:00Z"
   },
   {
     "ancestors": [
@@ -47,7 +47,7 @@
     "name": "//networksecurity.googleapis.com/projects/ccm-breakit/locations/global/serverTlsPolicies/td_mtls_policy",
     "resource": {
       "data": {
-        "createTime": "2025-07-29T16:00:12.082558809Z",
+        "createTime": "2025-08-05T16:25:14.331708131Z",
         "description": "my description",
         "labels": {
           "foo": "bar"
@@ -67,7 +67,7 @@
             "pluginInstance": "google_cloud_private_spiffe"
           }
         },
-        "updateTime": "2025-07-29T16:00:15.692522561Z"
+        "updateTime": "2025-08-05T16:25:21.045078465Z"
       },
       "discovery_document_uri": "https://networksecurity.googleapis.com/$discovery/rest",
       "discovery_name": "ServerTlsPolicy",
@@ -75,7 +75,7 @@
       "parent": "//cloudresourcemanager.googleapis.com/projects/307841421122",
       "version": "v1"
     },
-    "updateTime": "2025-07-29T18:00:00Z"
+    "updateTime": "2025-08-05T18:00:00Z"
   },
   {
     "ancestors": [
@@ -91,7 +91,7 @@
     "name": "//networksecurity.googleapis.com/projects/ccm-breakit/locations/global/serverTlsPolicies/td_with_server_cert_policy",
     "resource": {
       "data": {
-        "createTime": "2025-07-29T16:00:12.040588118Z",
+        "createTime": "2025-08-05T16:25:14.329850656Z",
         "description": "my description",
         "name": "projects/ccm-breakit/locations/global/serverTlsPolicies/td_with_server_cert_policy",
         "serverCertificate": {
@@ -99,7 +99,7 @@
             "targetUri": "unix:mypath"
           }
         },
-        "updateTime": "2025-07-29T16:00:15.680321984Z"
+        "updateTime": "2025-08-05T16:25:21.191035565Z"
       },
       "discovery_document_uri": "https://networksecurity.googleapis.com/$discovery/rest",
       "discovery_name": "ServerTlsPolicy",
@@ -107,7 +107,7 @@
       "parent": "//cloudresourcemanager.googleapis.com/projects/307841421122",
       "version": "v1"
     },
-    "updateTime": "2025-07-29T18:00:00Z"
+    "updateTime": "2025-08-05T18:00:00Z"
   },
   {
     "ancestors": [
@@ -123,7 +123,7 @@
     "name": "//networksecurity.googleapis.com/projects/ccm-breakit/locations/global/serverTlsPolicies/empty_description_policy",
     "resource": {
       "data": {
-        "createTime": "2025-07-29T16:00:11.660089355Z",
+        "createTime": "2025-08-05T16:25:14.331267507Z",
         "labels": {
           "foo": "bar"
         },
@@ -132,7 +132,7 @@
           "clientValidationTrustConfig": "projects/307841421122/locations/global/trustConfigs/id-4adf7779-1e9f-4124-9438-652c80886074"
         },
         "name": "projects/ccm-breakit/locations/global/serverTlsPolicies/empty_description_policy",
-        "updateTime": "2025-07-29T16:00:16.847799545Z"
+        "updateTime": "2025-08-05T16:25:20.756907211Z"
       },
       "discovery_document_uri": "https://networksecurity.googleapis.com/$discovery/rest",
       "discovery_name": "ServerTlsPolicy",
@@ -140,7 +140,7 @@
       "parent": "//cloudresourcemanager.googleapis.com/projects/307841421122",
       "version": "v1"
     },
-    "updateTime": "2025-07-29T18:00:00Z"
+    "updateTime": "2025-08-05T18:00:00Z"
   },
   {
     "ancestors": [
@@ -156,14 +156,14 @@
     "name": "//networksecurity.googleapis.com/projects/ccm-breakit/locations/global/serverTlsPolicies/empty_labels_policy",
     "resource": {
       "data": {
-        "createTime": "2025-07-29T16:00:12.040240475Z",
+        "createTime": "2025-08-05T16:25:14.329866696Z",
         "description": "my description",
         "mtlsPolicy": {
           "clientValidationMode": "REJECT_INVALID",
           "clientValidationTrustConfig": "projects/307841421122/locations/global/trustConfigs/id-4adf7779-1e9f-4124-9438-652c80886074"
         },
         "name": "projects/ccm-breakit/locations/global/serverTlsPolicies/empty_labels_policy",
-        "updateTime": "2025-07-29T16:00:16.309813819Z"
+        "updateTime": "2025-08-05T16:25:21.154695297Z"
       },
       "discovery_document_uri": "https://networksecurity.googleapis.com/$discovery/rest",
       "discovery_name": "ServerTlsPolicy",
@@ -171,7 +171,7 @@
       "parent": "//cloudresourcemanager.googleapis.com/projects/307841421122",
       "version": "v1"
     },
-    "updateTime": "2025-07-29T18:00:00Z"
+    "updateTime": "2025-08-05T18:00:00Z"
   },
   {
     "ancestors": [
@@ -187,7 +187,7 @@
     "name": "//networksecurity.googleapis.com/projects/ccm-breakit/locations/us-central1/serverTlsPolicies/regional_location_policy",
     "resource": {
       "data": {
-        "createTime": "2025-07-29T16:00:12.162242768Z",
+        "createTime": "2025-08-05T16:25:14.329828351Z",
         "description": "my description",
         "labels": {
           "foo": "bar"
@@ -197,7 +197,7 @@
           "clientValidationTrustConfig": "projects/307841421122/locations/us-central1/trustConfigs/tsmx-20250609-tc1"
         },
         "name": "projects/ccm-breakit/locations/us-central1/serverTlsPolicies/regional_location_policy",
-        "updateTime": "2025-07-29T16:00:15.08724113Z"
+        "updateTime": "2025-08-05T16:25:16.997166259Z"
       },
       "discovery_document_uri": "https://networksecurity.googleapis.com/$discovery/rest",
       "discovery_name": "ServerTlsPolicy",
@@ -205,7 +205,7 @@
       "parent": "//cloudresourcemanager.googleapis.com/projects/307841421122",
       "version": "v1"
     },
-    "updateTime": "2025-07-29T18:00:00Z"
+    "updateTime": "2025-08-05T18:00:00Z"
   },
   {
     "ancestors": [
@@ -221,7 +221,7 @@
     "name": "//networksecurity.googleapis.com/projects/ccm-breakit/locations/global/serverTlsPolicies/lb_mtls_allow_invalid_cert_policy",
     "resource": {
       "data": {
-        "createTime": "2025-07-29T16:00:12.078450339Z",
+        "createTime": "2025-08-05T16:25:14.263043415Z",
         "description": "my description",
         "labels": {
           "foo": "bar"
@@ -230,7 +230,7 @@
           "clientValidationMode": "ALLOW_INVALID_OR_MISSING_CLIENT_CERT"
         },
         "name": "projects/ccm-breakit/locations/global/serverTlsPolicies/lb_mtls_allow_invalid_cert_policy",
-        "updateTime": "2025-07-29T16:00:16.300643457Z"
+        "updateTime": "2025-08-05T16:25:16.933670463Z"
       },
       "discovery_document_uri": "https://networksecurity.googleapis.com/$discovery/rest",
       "discovery_name": "ServerTlsPolicy",
@@ -238,7 +238,7 @@
       "parent": "//cloudresourcemanager.googleapis.com/projects/307841421122",
       "version": "v1"
     },
-    "updateTime": "2025-07-29T18:00:00Z"
+    "updateTime": "2025-08-05T18:00:00Z"
   },
   {
     "ancestors": [
@@ -255,7 +255,7 @@
     "resource": {
       "data": {
         "allowOpen": true,
-        "createTime": "2025-07-29T16:00:11.930403186Z",
+        "createTime": "2025-08-05T16:25:14.331474263Z",
         "description": "my description",
         "mtlsPolicy": {
           "clientValidationCa": [
@@ -272,7 +272,7 @@
             "targetUri": "unix:mypath"
           }
         },
-        "updateTime": "2025-07-29T16:00:15.644106332Z"
+        "updateTime": "2025-08-05T16:25:21.254620046Z"
       },
       "discovery_document_uri": "https://networksecurity.googleapis.com/$discovery/rest",
       "discovery_name": "ServerTlsPolicy",
@@ -280,7 +280,7 @@
       "parent": "//cloudresourcemanager.googleapis.com/projects/307841421122",
       "version": "v1"
     },
-    "updateTime": "2025-07-29T18:00:00Z"
+    "updateTime": "2025-08-05T18:00:00Z"
   },
   {
     "ancestors": [
@@ -296,7 +296,7 @@
     "name": "//networksecurity.googleapis.com/projects/ccm-breakit/locations/global/serverTlsPolicies/td_with_cert_provider_policy",
     "resource": {
       "data": {
-        "createTime": "2025-07-29T16:00:12.122393281Z",
+        "createTime": "2025-08-05T16:25:14.331269202Z",
         "description": "my description",
         "name": "projects/ccm-breakit/locations/global/serverTlsPolicies/td_with_cert_provider_policy",
         "serverCertificate": {
@@ -304,7 +304,7 @@
             "pluginInstance": "google_cloud_private_spiffe"
           }
         },
-        "updateTime": "2025-07-29T16:00:15.720820072Z"
+        "updateTime": "2025-08-05T16:25:18.095425719Z"
       },
       "discovery_document_uri": "https://networksecurity.googleapis.com/$discovery/rest",
       "discovery_name": "ServerTlsPolicy",
@@ -312,7 +312,7 @@
       "parent": "//cloudresourcemanager.googleapis.com/projects/307841421122",
       "version": "v1"
     },
-    "updateTime": "2025-07-29T18:00:00Z"
+    "updateTime": "2025-08-05T18:00:00Z"
   },
   {
     "ancestors": [
@@ -328,7 +328,7 @@
     "name": "//networksecurity.googleapis.com/projects/ccm-breakit/locations/global/serverTlsPolicies/td_mtls_client_validation_grpc_policy",
     "resource": {
       "data": {
-        "createTime": "2025-07-29T16:00:12.000713965Z",
+        "createTime": "2025-08-05T16:25:14.331720924Z",
         "description": "my description",
         "labels": {
           "foo": "bar"
@@ -348,7 +348,7 @@
             "pluginInstance": "google_cloud_private_spiffe"
           }
         },
-        "updateTime": "2025-07-29T16:00:15.701713898Z"
+        "updateTime": "2025-08-05T16:25:21.209045286Z"
       },
       "discovery_document_uri": "https://networksecurity.googleapis.com/$discovery/rest",
       "discovery_name": "ServerTlsPolicy",
@@ -356,6 +356,6 @@
       "parent": "//cloudresourcemanager.googleapis.com/projects/307841421122",
       "version": "v1"
     },
-    "updateTime": "2025-07-29T18:00:00Z"
+    "updateTime": "2025-08-05T18:00:00Z"
   }
 ]

--- a/cai2hcl/services/networksecurity/testdata/server_tls_policy.tf
+++ b/cai2hcl/services/networksecurity/testdata/server_tls_policy.tf
@@ -1,0 +1,194 @@
+resource "google_network_security_server_tls_policy" "lb_mtls_policy" {
+  allow_open  = false
+  description = "my description"
+
+  labels = {
+    foo = "bar"
+  }
+
+  location = "global"
+
+  mtls_policy {
+    client_validation_mode         = "REJECT_INVALID"
+    client_validation_trust_config = "projects/307841421122/locations/global/trustConfigs/id-4adf7779-1e9f-4124-9438-652c80886074"
+  }
+
+  name    = "lb_mtls_policy"
+  project = "ccm-breakit"
+}
+
+resource "google_network_security_server_tls_policy" "td_mtls_policy" {
+  allow_open  = false
+  description = "my description"
+
+  labels = {
+    foo = "bar"
+  }
+
+  location = "global"
+
+  mtls_policy {
+    client_validation_ca {
+      certificate_provider_instance {
+        plugin_instance = "google_cloud_private_spiffe"
+      }
+    }
+  }
+
+  name    = "td_mtls_policy"
+  project = "ccm-breakit"
+
+  server_certificate {
+    certificate_provider_instance {
+      plugin_instance = "google_cloud_private_spiffe"
+    }
+  }
+}
+
+resource "google_network_security_server_tls_policy" "td_with_server_cert_policy" {
+  allow_open  = false
+  description = "my description"
+  location    = "global"
+  name        = "td_with_server_cert_policy"
+  project     = "ccm-breakit"
+
+  server_certificate {
+    grpc_endpoint {
+      target_uri = "unix:mypath"
+    }
+  }
+}
+
+resource "google_network_security_server_tls_policy" "empty_description_policy" {
+  allow_open = false
+
+  labels = {
+    foo = "bar"
+  }
+
+  location = "global"
+
+  mtls_policy {
+    client_validation_mode         = "REJECT_INVALID"
+    client_validation_trust_config = "projects/307841421122/locations/global/trustConfigs/id-4adf7779-1e9f-4124-9438-652c80886074"
+  }
+
+  name    = "empty_description_policy"
+  project = "ccm-breakit"
+}
+
+resource "google_network_security_server_tls_policy" "empty_labels_policy" {
+  allow_open  = false
+  description = "my description"
+  location    = "global"
+
+  mtls_policy {
+    client_validation_mode         = "REJECT_INVALID"
+    client_validation_trust_config = "projects/307841421122/locations/global/trustConfigs/id-4adf7779-1e9f-4124-9438-652c80886074"
+  }
+
+  name    = "empty_labels_policy"
+  project = "ccm-breakit"
+}
+
+resource "google_network_security_server_tls_policy" "regional_location_policy" {
+  allow_open  = false
+  description = "my description"
+
+  labels = {
+    foo = "bar"
+  }
+
+  location = "us-central1"
+
+  mtls_policy {
+    client_validation_mode         = "REJECT_INVALID"
+    client_validation_trust_config = "projects/307841421122/locations/us-central1/trustConfigs/tsmx-20250609-tc1"
+  }
+
+  name    = "regional_location_policy"
+  project = "ccm-breakit"
+}
+
+resource "google_network_security_server_tls_policy" "lb_mtls_allow_invalid_cert_policy" {
+  allow_open  = false
+  description = "my description"
+
+  labels = {
+    foo = "bar"
+  }
+
+  location = "global"
+
+  mtls_policy {
+    client_validation_mode = "ALLOW_INVALID_OR_MISSING_CLIENT_CERT"
+  }
+
+  name    = "lb_mtls_allow_invalid_cert_policy"
+  project = "ccm-breakit"
+}
+
+resource "google_network_security_server_tls_policy" "td_allow_open_policy" {
+  allow_open  = true
+  description = "my description"
+  location    = "global"
+
+  mtls_policy {
+    client_validation_ca {
+      certificate_provider_instance {
+        plugin_instance = "google_cloud_private_spiffe"
+      }
+    }
+  }
+
+  name    = "td_allow_open_policy"
+  project = "ccm-breakit"
+
+  server_certificate {
+    grpc_endpoint {
+      target_uri = "unix:mypath"
+    }
+  }
+}
+
+resource "google_network_security_server_tls_policy" "td_with_cert_provider_policy" {
+  allow_open  = false
+  description = "my description"
+  location    = "global"
+  name        = "td_with_cert_provider_policy"
+  project     = "ccm-breakit"
+
+  server_certificate {
+    certificate_provider_instance {
+      plugin_instance = "google_cloud_private_spiffe"
+    }
+  }
+}
+
+resource "google_network_security_server_tls_policy" "td_mtls_client_validation_grpc_policy" {
+  allow_open  = false
+  description = "my description"
+
+  labels = {
+    foo = "bar"
+  }
+
+  location = "global"
+
+  mtls_policy {
+    client_validation_ca {
+      grpc_endpoint {
+        target_uri = "unix:mypath"
+      }
+    }
+  }
+
+  name    = "td_mtls_client_validation_grpc_policy"
+  project = "ccm-breakit"
+
+  server_certificate {
+    certificate_provider_instance {
+      plugin_instance = "google_cloud_private_spiffe"
+    }
+  }
+}


### PR DESCRIPTION
**Summary**
This PR backports Networksecurity Server TLS Policy to TGC v5. Changes compared to v6 are:
- Parse `location` from name instead of CAI Asset field. We do this to keep impact on TGC v5 minimal.
- Testdata generated with v5 provider.

Caveat: We omit the `provider = google-beta` field from the output since v6 does not require Preview/Beta provider anymore. 

**Context**
CCM will use Terrashot service for Pantheon equivalent Terraform feature. Terrashot uses TGC v5, hence the backporting. Discussed with @zli82016