### PR TITLE
`chore: upgrade to go 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/GoogleCloudPlatform/terraform-google-conversion/v6
 
-go 1.23.0
-
-toolchain go1.23.5
+go 1.24.0
 
 require (
 	cloud.google.com/go/storage v1.52.0


### PR DESCRIPTION
upgrade of golang after upgrading the golang version in magic-modules

- https://github.com/GoogleCloudPlatform/magic-modules/pull/15293